### PR TITLE
[Config] Nginx를 통한 Local Https + Local 임시 Domain 연결 Setting (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### pem ###
+.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+
+  nginx:
+    image: nginx:latest
+    container_name: dungeontalk-nginx
+    ports:
+      - "443:443"
+      - "80:80"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d # Nginx 설정
+      - ./nginx/certs:/etc/nginx/certs # 인증서 마운트
+    networks:
+      - dungeontalk-net
+
+networks:
+  dungeontalk-net:
+    driver: bridge

--- a/nginx/Guide.txt
+++ b/nginx/Guide.txt
@@ -1,0 +1,11 @@
+### <Nginx를 통한 Local Https 설정 + Local Domain 적용에 대한 가이드>
+
+What : Nginx를 통한 Local Https 설정 + Local Domain 적용
+When : 2025-08-04
+Who : 류성열
+
+<Test>
+테스트 링크 : https://api.dt.com/NginxTest.html
+
+위 링크를 브라우저에 입력할 때,
+"Spring Boot 정적 리소스 테스트 성공!"라는 메시지가 나오면 성공입니다.

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,19 @@
+server {
+
+    listen 443 ssl;
+    server_name api.dt.com;
+
+    ssl_certificate /etc/nginx/certs/api.dt.com.pem;
+    ssl_certificate_key /etc/nginx/certs/api.dt.com-key.pem;
+
+    location / {
+
+        # < 선택 1. Spring Webflux 서버를 컨테이너가 아닌, 로컬로 실행시 >
+        proxy_pass http://host.docker.internal:8080;
+        # < 선택 2. Spring WebFlux 서버를 도커 컨테이너로 실행시>
+        # proxy_pass http://webflux:8080;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/src/main/resources/static/NginxTest.html
+++ b/src/main/resources/static/NginxTest.html
@@ -1,0 +1,11 @@
+<!-- src/main/resources/static/NginxTest.html -->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>테스트 성공</title>
+</head>
+<body>
+<h1>Spring Boot 정적 리소스 테스트 성공!</h1>
+</body>
+</html>


### PR DESCRIPTION
# 요약

개발 내용에 대한 요약은 다음과 같습니다.   
1. Local 개발용 임시 Domain 설정 (유저의 Local Host 파일에 127.0.0.1 api.dt.com 추가 )
2. mkcert를 통한 셀프 인증 환경 구축  (Let's encrypt는 배포 환경에서만 사용 가능함)
3. 우리의 임시 도메인 api.dt.com에 대한 인증서, 키 발급 
4. Nginx를 통한 Local Domain 연결 및 Local Https 설정 
5. docker-compose 에 Nginx 설정 및 인증서에 대한 볼륨 추가 
6. resources>static 디렉토리 내부에 NginxTest.html 파일을 구현해 테스트 완료 

### 기타 
<운영체제 별 host 파일 경로 >
<img width="454" height="168" alt="image" src="https://github.com/user-attachments/assets/fae64ef6-f1f5-41b5-8ea2-dc4de00e09e8" />

<Nginx 디렉토리 구조>
<img width="414" height="247" alt="image" src="https://github.com/user-attachments/assets/e4693136-9ed7-4663-a7fe-a0af05c61284" />

<Spring Boot 프로젝트 실행 방식에 따른 선택 : 로컬 Vs 컨테이너>
다음은 nginx의 default.conf의 일부이다.
```
        # < 선택 1. Spring Webflux 서버를 컨테이너가 아닌, 로컬로 실행시 >
        proxy_pass http://host.docker.internal:8080;
        # < 선택 2. Spring WebFlux 서버를 도커 컨테이너로 실행시>
        # proxy_pass http://webflux:8080;

```


### 다음은 테스트 성공 화면 입니다.
브라우저에 https://api.dt.com/NginxTest.html 를 입력하고 다음 화면이 나오면 성공입니다.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/56ca5c7a-fc6f-46dd-8381-1df7a68e8375" />

# 연관 이슈 및 Close 할 이슈 작성
Config/#4

close Config/#4

# Pull Request 체크리스트

## TODO

- [ v ] 최종 결과물을 확인했는가?
- [ v ] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Nginx를 이용한 HTTPS 및 로컬 도메인(`api.dt.com`) 프록시 설정이 추가되었습니다.
  * Spring Boot 정적 리소스 테스트용 HTML 파일이 추가되었습니다.

* **문서**
  * Nginx 환경 설정 및 로컬 HTTPS 적용 방법에 대한 가이드 문서가 추가되었습니다.

* **기타**
  * `.pem` 확장자 파일이 git 추적에서 제외되었습니다.
  * Docker Compose를 통한 Nginx 서비스 및 네트워크 구성이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->