### PR TITLE
feat(Auth) 로그인 Valkey 이슈 해결 및 기초 인증&인가 시스템 구축 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ dependencies {
     // UUID v7 지원용 라이브러리
     implementation 'com.github.f4b6a3:uuid-creator:5.3.2'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // UUID v7 지원용 라이브러리
+    implementation 'com.github.f4b6a3:uuid-creator:5.3.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/com/dungeontalk/DungeontalkApplication.java
+++ b/src/main/java/org/com/dungeontalk/DungeontalkApplication.java
@@ -2,7 +2,9 @@ package org.com.dungeontalk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DungeontalkApplication {
 

--- a/src/main/java/org/com/dungeontalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/controller/AuthController.java
@@ -1,0 +1,34 @@
+package org.com.dungeontalk.domain.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.com.dungeontalk.domain.auth.dto.request.AuthLoginRequest;
+import org.com.dungeontalk.domain.auth.dto.response.AuthLoginResponse;
+import org.com.dungeontalk.domain.auth.service.AuthService;
+import org.com.dungeontalk.global.rsData.RsData;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 로그인
+    @PostMapping("/login")
+    public RsData<AuthLoginResponse> login(@RequestBody AuthLoginRequest request) {
+        AuthLoginResponse response = authService.login(request);
+        return RsData.of("200", "로그인 성공", response);
+    }
+
+    // 로그 아웃
+    @PostMapping("/logout")
+    public RsData<String> logout(HttpServletRequest request) {
+        authService.logout(request);
+        return RsData.of("200", "로그아웃 완료", null);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
@@ -1,0 +1,23 @@
+package org.com.dungeontalk.domain.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.com.dungeontalk.domain.auth.service.ValkeyService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/valkey")
+@RequiredArgsConstructor
+public class ValkeyController {
+
+    private final ValkeyService valkeyService;
+
+    // 현재 우리 세션 valkey에 등록된 유저들의 토큰을 모두 조회하는 컨트롤러
+    @GetMapping("/session/all")
+    public Map<String, String> getAllSessionData() {
+        return valkeyService.getAllSessionRedisData();
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
@@ -6,7 +6,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/v1/valkey")
@@ -15,9 +18,26 @@ public class ValkeyController {
 
     private final ValkeyService valkeyService;
 
+    // 테스트용 세션 데이터 저장 (Key, Value 입력)
+    @GetMapping("/session/test/save")
+    public String saveTestSessionData() {
+        String key = "test-key" + LocalDateTime.now();
+        String value = LocalDateTime.now().toString();
+        valkeyService.saveSessionData(key, value);
+        return "Saved test session data: " + key + " = " + value;
+    }
+
     // 현재 우리 세션 valkey에 등록된 유저들의 토큰을 모두 조회하는 컨트롤러
     @GetMapping("/session/all")
     public Map<String, String> getAllSessionData() {
-        return valkeyService.getAllSessionRedisData();
+
+        return valkeyService.getAllTestKeySessionData();
     }
+
+    // 현재 모든 세션의 데이터를 키값만 조회
+    @GetMapping("/session/keys")
+    public Set<String> getAllSessionKeys() {
+        return valkeyService.getAllSessionKeys();
+    }
+
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/dto/request/AuthLoginRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/dto/request/AuthLoginRequest.java
@@ -1,0 +1,7 @@
+package org.com.dungeontalk.domain.auth.dto.request;
+
+public record AuthLoginRequest(
+        String name,
+        String password
+) {
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/dto/response/AuthLoginResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/dto/response/AuthLoginResponse.java
@@ -1,0 +1,8 @@
+package org.com.dungeontalk.domain.auth.dto.response;
+
+public record AuthLoginResponse(
+        String memberId,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/entity/Auth.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/entity/Auth.java
@@ -2,7 +2,9 @@ package org.com.dungeontalk.domain.auth.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.com.dungeontalk.domain.member.entity.Member;
+import org.com.dungeontalk.global.common.entity.BaseEntity;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,22 +16,23 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class Auth {
+@SuperBuilder
+public class Auth extends BaseEntity {
 
-    @EmbeddedId
-    private AuthId authId;
-
+//    @EmbeddedId
+//    private AuthId authId;
     // ManyToOne으로 member 참조 (member_id 필드와 연동)
-    @MapsId("memberId") // AuthId.memberId와 매핑
+    //@MapsId("memberId") // AuthId.memberId와 매핑
+
+    //@JoinColumn(name = "member_id", insertable = false, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", insertable = false, updatable = false)
+    @JoinColumn(name = "member_id")  // insertable/updatable 옵션 제거
     private Member member;
 
     @Column(name = "email", length = 50)
     private String email;
 
-    @Column(name = "token_type", length = 20)
+    @Column(name = "token_type")
     private String tokenType;
 
     // 실제 토큰 길이가 짧으면 저장 못합니다. 안전하게 text로 둡시다.
@@ -39,11 +42,11 @@ public class Auth {
     @Column(name = "refresh_token", columnDefinition = "text")
     private String refreshToken;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+//    @CreationTimestamp
+//    @Column(name = "created_at", updatable = false)
+//    private LocalDateTime createdAt;
+//
+//    @UpdateTimestamp
+//    @Column(name = "updated_at")
+//    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/repository/AuthRepository.java
@@ -1,8 +1,14 @@
 package org.com.dungeontalk.domain.auth.repository;
 
 import org.com.dungeontalk.domain.auth.entity.Auth;
-import org.com.dungeontalk.domain.auth.entity.AuthId;
+import org.com.dungeontalk.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AuthRepository extends JpaRepository<Auth, AuthId> {
+import java.util.Optional;
+
+public interface AuthRepository extends JpaRepository<Auth, String> {
+
+    Optional<Auth> findByMember(Member member);
+
+    Optional<Auth> findByMember_Id(String memberId);
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
@@ -1,0 +1,133 @@
+package org.com.dungeontalk.domain.auth.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.auth.dto.request.AuthLoginRequest;
+import org.com.dungeontalk.domain.auth.dto.response.AuthLoginResponse;
+import org.com.dungeontalk.domain.auth.entity.Auth;
+import org.com.dungeontalk.domain.auth.entity.AuthId;
+import org.com.dungeontalk.domain.auth.repository.AuthRepository;
+import org.com.dungeontalk.domain.member.entity.Member;
+import org.com.dungeontalk.domain.member.repository.MemberRepository;
+import org.com.dungeontalk.global.exception.ErrorCode;
+import org.com.dungeontalk.global.exception.customException.MemberException;
+import org.com.dungeontalk.global.security.JwtService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private static final String PROVIDER_LOCAL = "LOCAL";
+
+    private final MemberRepository memberRepository;
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    // 로그인 메서드
+    public AuthLoginResponse login(AuthLoginRequest request) {
+
+        // 1. 회원 조회 (name 기준)
+        Member member = memberRepository.findByName(request.name())
+                .orElseThrow(() -> new MemberException(ErrorCode.GLOBAL_ERROR));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new MemberException(ErrorCode.GLOBAL_ERROR);
+        }
+
+        // 3. 토큰 생성
+        String accessToken = jwtService.generateAccessToken(member.getId(), member.getName(), member.getNickName());
+        String refreshToken = jwtService.generateRefreshToken(member.getId(), member.getName(), member.getNickName());
+        log.info("엑세스 토큰 생성 : {}",accessToken);
+        log.info("리프레시 토큰 생성 : {}",refreshToken);
+
+        // 4. Auth 엔티티 갱신 또는 생성 (AuthId 사용하지 않음)
+        Optional<Auth> existingAuthOpt = authRepository.findByMember(member);
+        log.info("existingAuthOpt : {}", existingAuthOpt);
+
+        if (existingAuthOpt.isPresent()) {
+            log.info("1");
+            Auth auth = existingAuthOpt.get();
+            auth.setAccessToken(accessToken);
+            auth.setRefreshToken(refreshToken);
+            authRepository.save(auth);
+            log.info("2");
+        } else {
+            log.info("3");
+            Auth newAuth = Auth.builder()
+                    .member(member)
+                    .email(member.getName())
+                    .tokenType("bearer")
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+            log.info("newAuth: {}", newAuth);
+            log.info("4");
+            authRepository.save(newAuth);
+            log.info("5");
+        }
+
+        // RefreshToken을 세션 레디스에 저장
+        // todo : Accesstoken또 추가하기
+        // jwtService.saveRefreshTokenToSessionRedis(member.getId(), refreshToken);
+
+        log.info("7");
+        return new AuthLoginResponse(
+                member.getId(),
+                accessToken,
+                refreshToken
+        );
+    }
+
+    // 로그 아웃 메서드
+    public void logout(HttpServletRequest request) {
+        String accessToken = jwtService.extractAccessToken(request);
+        if (accessToken == null) {
+            log.warn("logout called but access token is missing");
+            SecurityContextHolder.clearContext();
+            return;
+        }
+
+        // 2) 토큰에서 memberId 추출
+        String memberId;
+        try {
+            memberId = jwtService.extractIdFromToken(accessToken);
+        } catch (Exception ex) {
+            log.warn("failed to extract member id from token during logout: {}", ex.getMessage());
+            SecurityContextHolder.clearContext();
+            return;
+        }
+
+        // 3) Auth 레코드 찾아 토큰 제거
+//        AuthId authId = new AuthId(PROVIDER_LOCAL, memberId);
+//        Optional<Auth> authOpt = authRepository.findById(authId);
+
+        // Auth 레코드 찾아 토큰 제거 (memberId로 직접 조회)
+        Optional<Auth> authOpt = authRepository.findByMember_Id(memberId);
+        if (authOpt.isPresent()) {
+            Auth auth = authOpt.get();
+            auth.setAccessToken(null);
+            auth.setRefreshToken(null);
+            authRepository.save(auth);
+            log.info("cleared auth tokens for memberId={}", memberId);
+        } else {
+            log.info("no auth record found for memberId={} during logout", memberId);
+        }
+
+        // (권장) JwtService에 레디스에서 refresh token 삭제하는 메서드가 있다면 호출하세요.
+        // ex) jwtService.deleteRefreshTokenFromSessionRedis(memberId);
+
+        // 4) Security context clear
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
@@ -26,8 +26,6 @@ import java.util.Optional;
 @Transactional
 public class AuthService {
 
-    private static final String PROVIDER_LOCAL = "LOCAL";
-
     private final MemberRepository memberRepository;
     private final AuthRepository authRepository;
     private final PasswordEncoder passwordEncoder;

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
@@ -71,7 +71,7 @@ public class AuthService {
         }
 
         // session에 저장
-        // jwtService.saveRefreshTokenToSessionRedis(member.getId(), refreshToken);
+        jwtService.saveRefreshTokenToSessionRedis(member.getId(), refreshToken);
 
         return new AuthLoginResponse(
                 member.getId(),

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
@@ -23,28 +23,34 @@ public class ValkeyService {
         this.cacheRedis = cacheRedis;
         this.sessionRedis = sessionRedis;
         this.memberRepository = memberRepository;
-
-
-
     }
 
+    // Redis 세션에 단일 키-값 저장
+    public void saveSessionData(String key, String value) {
+        sessionRedis.opsForValue().set(key, value);
+    }
 
-    /**
-     * Redis에 저장된 모든 키와 값을 Map 형태로 반환
-     */
-    public Map<String, String> getAllSessionRedisData() {
-        Map<String, String> data = new HashMap<>();
+    // Redis 세션에 저장된 test키 모두 조회
+    public Map<String, String> getAllTestKeySessionData() {
+        String pattern = "test-key*";  // test-key로 시작하는 모든 키 조회
+        Set<String> keys = sessionRedis.keys(pattern);
+        Map<String, String> result = new HashMap<>();
 
-        // 모든 키 조회 (주의: 대규모 데이터일 경우 성능 문제 발생 가능)
-        Set<String> keys = sessionRedis.keys("*");
-
-        if (keys != null && !keys.isEmpty()) {
+        if (keys != null) {
             for (String key : keys) {
-                String value = sessionRedis.opsForValue().get(key);
-                data.put(key, value);
+                String value = sessionRedis.opsForValue().get(key);  // String 타입 값 조회
+                result.put(key, value);
             }
         }
 
-        return data;
+        return result;
     }
+
+
+    public Set<String> getAllSessionKeys() {
+        // 모든 키 조회 (키만 반환)
+        return sessionRedis.keys("*");
+    }
+
+
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
@@ -1,0 +1,50 @@
+package org.com.dungeontalk.domain.auth.service;
+
+import org.com.dungeontalk.domain.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class ValkeyService {
+
+    private final RedisTemplate<String, String> cacheRedis;
+    private final RedisTemplate<String, String> sessionRedis;
+    private final MemberRepository memberRepository;
+
+    public ValkeyService(
+            @Qualifier("cacheRedisTemplate") RedisTemplate<String, String> cacheRedis,
+            @Qualifier("sessionRedisTemplate") RedisTemplate<String, String> sessionRedis,
+            MemberRepository memberRepository) {
+        this.cacheRedis = cacheRedis;
+        this.sessionRedis = sessionRedis;
+        this.memberRepository = memberRepository;
+
+
+
+    }
+
+
+    /**
+     * Redis에 저장된 모든 키와 값을 Map 형태로 반환
+     */
+    public Map<String, String> getAllSessionRedisData() {
+        Map<String, String> data = new HashMap<>();
+
+        // 모든 키 조회 (주의: 대규모 데이터일 경우 성능 문제 발생 가능)
+        Set<String> keys = sessionRedis.keys("*");
+
+        if (keys != null && !keys.isEmpty()) {
+            for (String key : keys) {
+                String value = sessionRedis.opsForValue().get(key);
+                data.put(key, value);
+            }
+        }
+
+        return data;
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/member/controller/MemberController.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/controller/MemberController.java
@@ -21,6 +21,10 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 회원가입 컨트롤러
+     * @param registerRequest - 회원가입 요청 DTO
+     */
     @PostMapping("/register")
     public RsData<RegisterResponse> register(@RequestBody @Valid RegisterRequest registerRequest) {
         RegisterResponse registerResponse = memberService.register(registerRequest);

--- a/src/main/java/org/com/dungeontalk/domain/member/dto/request/RegisterRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/dto/request/RegisterRequest.java
@@ -16,9 +16,8 @@ public record RegisterRequest(
         // @Size(min = 2, max = 128, message = "비밀번호는 최소 2자 이상이어야 합니다.")
         String password
 ) {
-    public Member toEntity(String id,  String encodedPassword) {
+    public Member toEntity(String encodedPassword) {
         return Member.builder()
-                .id(id)
                 .name(this.name)
                 .nickName(this.nickName)
                 .password(encodedPassword)

--- a/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package org.com.dungeontalk.domain.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.com.dungeontalk.global.common.entity.BaseEntity;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,11 +15,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Member {
+public class Member extends BaseEntity {
 
-    @Id
-    @Column(name = "id", nullable = false)
-    private String id;
+//    @Id
+//    @Column(name = "id", nullable = false)
+//    private String id;
 
     @Column(name = "password", nullable = false)
     private String password;
@@ -29,11 +30,11 @@ public class Member {
     @Column(name = "nick_name",  unique = true)
     private String nickName;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+//    @CreationTimestamp
+//    @Column(name = "created_at", updatable = false)
+//    private LocalDateTime createdAt;
+//
+//    @UpdateTimestamp
+//    @Column(name = "updated_at")
+//    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package org.com.dungeontalk.domain.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -11,10 +12,9 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "member")
 @Getter
-@Setter
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class Member extends BaseEntity {
 
 //    @Id

--- a/src/main/java/org/com/dungeontalk/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/repository/MemberRepository.java
@@ -14,4 +14,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByName(String name);
 
 
+
+
 }

--- a/src/main/java/org/com/dungeontalk/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/repository/MemberRepository.java
@@ -7,4 +7,11 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
+    // 중복 방지용 : 닉네임으로 유저 객체 찾기
+    Optional<Member> findByNickName(String nickName);
+
+    // 중복 방지용 : 아이디로 유저 객체 찾기
+    Optional<Member> findByName(String name);
+
+
 }

--- a/src/main/java/org/com/dungeontalk/domain/member/service/MemberService.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/service/MemberService.java
@@ -24,19 +24,22 @@ public class MemberService {
     @Transactional
     public RegisterResponse register(RegisterRequest registerRequest) {
 
-        /* Name 중복 체크 추가하기 */
+        if (memberRepository.findByName(registerRequest.name()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
 
-        /* NickName 중복 체크 추가하기 */
-
-        /* UUID 7 적용하기 */
-        String id = "sfsdf"; // 일단 하드 코딩
+        if (memberRepository.findByNickName(registerRequest.nickName()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
 
         String encodedPassword = passwordEncoder.encode(registerRequest.password());
-        Member member = registerRequest.toEntity(id,encodedPassword);
+        Member member = registerRequest.toEntity(encodedPassword);
         memberRepository.save(member);
 
         return new RegisterResponse(member.getId(), member.getName(), member.getNickName());
     }
+
+
 
 
 }

--- a/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
+++ b/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
@@ -28,10 +28,10 @@ public class BaseEntity {
     private String id;
 
     @CreatedDate
-    private LocalDateTime createTime;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updateTime;
+    private LocalDateTime updatedAt;
 
     // UUID 자동 할당
     @PrePersist

--- a/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
+++ b/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
@@ -1,0 +1,44 @@
+package org.com.dungeontalk.global.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.com.dungeontalk.global.util.UuidV7Creator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@Setter
+@SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class BaseEntity {
+
+    /* BaseEntity를 상속받는 모든 모든 엔티티는 UUID7 과 생성 시각과 수정 시각을 자동으로 관리 */
+
+    @Id
+    private String id;
+
+    @CreatedDate
+    private LocalDateTime createTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateTime;
+
+    // UUID 자동 할당
+    @PrePersist
+    public void generateIdIfNull() {
+        if (this.id == null || this.id.isBlank()) {
+            this.id = UuidV7Creator.create();
+        }
+    }
+
+}

--- a/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
@@ -31,18 +31,19 @@ public class SecurityConfig {
                 // 시큐리티 기본 로그인 비활성화
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(req -> req.anyRequest().permitAll())
 
                 // 권한 url 설정
-                .authorizeHttpRequests(req -> req.
-                        requestMatchers("/v1/member/register").permitAll().
-                        requestMatchers("/v1/auth/login").permitAll().
-                        requestMatchers("/v1/valkey/session/all").permitAll().
-
-                        requestMatchers("/swagger-ui/**").permitAll().
-                        requestMatchers("/swagger-ui/index.html").permitAll().
-                        requestMatchers("/v3/api-docs/**").permitAll().
-                        requestMatchers("/webjars/").permitAll().
-                        anyRequest().authenticated())
+//                .authorizeHttpRequests(req -> req.
+//                        requestMatchers("/v1/member/register").permitAll().
+//                        requestMatchers("/v1/auth/login").permitAll().
+//                        requestMatchers("/v1/valkey/session/all").permitAll().
+//
+//                        requestMatchers("/swagger-ui/**").permitAll().
+//                        requestMatchers("/swagger-ui/index.html").permitAll().
+//                        requestMatchers("/v3/api-docs/**").permitAll().
+//                        requestMatchers("/webjars/").permitAll().
+//                        anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // 필터 추가
 
         return http.build();

--- a/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(req -> req.anyRequest().permitAll())
 
-                // 권한 url 설정
+                // 권한 url 설정 -> 우선은 개발단계니까 모두 허용
 //                .authorizeHttpRequests(req -> req.
 //                        requestMatchers("/v1/member/register").permitAll().
 //                        requestMatchers("/v1/auth/login").permitAll().

--- a/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(req -> req.
                         requestMatchers("/v1/member/register").permitAll().
                         requestMatchers("/v1/auth/login").permitAll().
+                        requestMatchers("/v1/valkey/session/all").permitAll().
 
                         requestMatchers("/swagger-ui/**").permitAll().
                         requestMatchers("/swagger-ui/index.html").permitAll().

--- a/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 // 권한 url 설정
                 .authorizeHttpRequests(req -> req.
                         requestMatchers("/v1/member/register").permitAll().
-                        requestMatchers("/v1/member/login").permitAll().
+                        requestMatchers("/v1/auth/login").permitAll().
 
                         requestMatchers("/swagger-ui/**").permitAll().
                         requestMatchers("/swagger-ui/index.html").permitAll().

--- a/src/main/java/org/com/dungeontalk/global/config/ValkeyConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/ValkeyConfig.java
@@ -15,10 +15,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class ValkeyConfig {
 
     // Session Redis 설정
-    @Value("${spring.data.redis.host}")
+    @Value("${spring.data.session.host}")
     private String sessionRedisHost;
 
-    @Value("${spring.data.redis.port}")
+    @Value("${spring.data.session.port}")
     private int sessionRedisPort;
 
     // Cache Redis 설정
@@ -31,14 +31,7 @@ public class ValkeyConfig {
 
     // ======================= Redis Basic Config =========================
 
-    /**
-     * 기본 이름의 redisTemplate
-     * <p>
-     * description : RedisTemplate의 기본 이름이 필요한 외부 또는 내부 컴포넌트를 에러 없이 동작시키기 위해 사용
-     *
-     * @param connectionFactory
-     * @return
-     */
+    // 기본적인 Redis 탬플릿
     @Bean(name = "redisTemplate")
     public RedisTemplate<String, String> redisTemplate(
             @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
@@ -47,11 +40,7 @@ public class ValkeyConfig {
 
     // ======================= Session Redis =========================
 
-    /**
-     * Session Redis Connection Factory
-     *
-     * @return
-     */
+    // Session(Valkey) 연결용 팩토리
     @Bean(name = "sessionRedisConnectionFactory")
     @Primary
     public RedisConnectionFactory sessionRedisConnectionFactory() {
@@ -62,18 +51,12 @@ public class ValkeyConfig {
         return new LettuceConnectionFactory(config);
     }
 
-    /**
-     * Session Redis Template (데이터 저장용)
-     *
-     * @param connectionFactory
-     * @return
-     */
+    // Session(Valkey) 저장용 템플릿
     @Bean(name = "sessionRedisTemplate")
     public RedisTemplate<String, String> sessionRedisTemplate(
             @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
-
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
 
@@ -82,11 +65,7 @@ public class ValkeyConfig {
 
     // ======================= Cache Redis =========================
 
-    /**
-     * Cache Redis Connection Factory
-     *
-     * @return
-     */
+    // cache(Valkey) 연결용 팩토리
     @Bean(name = "cacheRedisConnectionFactory")
     public RedisConnectionFactory cacheRedisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
@@ -96,12 +75,7 @@ public class ValkeyConfig {
         return new LettuceConnectionFactory(config);
     }
 
-    /**
-     * Cache Redis Template - redis를 직접 다룰 때 사용
-     *
-     * @param connectionFactory
-     * @return
-     */
+    // Cache(Valkey) 저장용 템플릿
     @Bean(name = "cacheRedisTemplate")
     public RedisTemplate<String, String> cacheRedisTemplate(
             @Qualifier("cacheRedisConnectionFactory") RedisConnectionFactory connectionFactory) {

--- a/src/main/java/org/com/dungeontalk/global/exception/ErrorCode.java
+++ b/src/main/java/org/com/dungeontalk/global/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     GLOBAL_ERROR("500-GL01", "서버 오류"),
     DATABASE_ERROR("500-DB01","데이터 베이스 오류");
 
+
+
     private final String errorCode;
     private final String message;
 

--- a/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
@@ -32,7 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/v1/member/register",
             "/v1/auth/login",
             "/swagger-ui",
-            "/v3/api-docs"
+            "/v3/api-docs",
+            "/v1/valkey/session/all"
            );
 
     // 필터 체인
@@ -47,7 +48,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
-
 
             String accessToken = jwtService.extractAccessToken(request);
 

--- a/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
@@ -23,18 +23,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 권한 체크가 불필요한 API들을 패스하는 메서드
     private boolean isPublicApi(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return PUBLIC_APIS.stream().anyMatch(path::startsWith);
+
+        return true;  // 모든 요청 인증 우회
+//        String path = request.getRequestURI();
+//        return PUBLIC_APIS.stream().anyMatch(path::startsWith);
     }
 
     // 권한 체크가 불필요한 API 리스트 정의 메서드
-    private static final List<String> PUBLIC_APIS = List.of(
-            "/v1/member/register",
-            "/v1/auth/login",
-            "/swagger-ui",
-            "/v3/api-docs",
-            "/v1/valkey/session/all"
-           );
+//    private static final List<String> PUBLIC_APIS = List.of(
+//            "/v1/member/register",
+//            "/v1/auth/login",
+//            "/swagger-ui",
+//            "/v3/api-docs",
+//            "/v1/valkey/session/all",
+//            "/v1/valkey/session/test/save"
+//           );
 
     // 필터 체인
     @Override

--- a/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
@@ -24,19 +24,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // 권한 체크가 불필요한 API들을 패스하는 메서드
     private boolean isPublicApi(HttpServletRequest request) {
 
-        return true;  // 모든 요청 인증 우회
+        // 일단은 개발 단계이므로, 모든 요청 인증 우회
+        return true;
 //        String path = request.getRequestURI();
 //        return PUBLIC_APIS.stream().anyMatch(path::startsWith);
     }
 
-    // 권한 체크가 불필요한 API 리스트 정의 메서드
+    /*
+    * 권한 체크가 불필요한 API 리스트 정의 메서드
+    *
+    * 일단은 개발 단계이므로 모든 API를 Open함
+    *  */
 //    private static final List<String> PUBLIC_APIS = List.of(
 //            "/v1/member/register",
 //            "/v1/auth/login",
-//            "/swagger-ui",
-//            "/v3/api-docs",
-//            "/v1/valkey/session/all",
-//            "/v1/valkey/session/test/save"
 //           );
 
     // 필터 체인

--- a/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // 권한 체크가 불필요한 API 리스트 정의 메서드
     private static final List<String> PUBLIC_APIS = List.of(
             "/v1/member/register",
-            "/v1/member/login",
+            "/v1/auth/login",
             "/swagger-ui",
             "/v3/api-docs"
            );

--- a/src/main/java/org/com/dungeontalk/global/security/JwtService.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtService.java
@@ -88,28 +88,10 @@ public class JwtService {
         return null;
     }
 
-    // Http 요청 객체에서 부터 고유 번호 추출
-    public String extractIdFromRequest(HttpServletRequest request) {
-        String accessToken = extractAccessToken(request);
-        return extractIdFromToken(accessToken);
-    }
-
     // 토큰에서 고유 번호 추출
     public String extractIdFromToken(String token) {
 
         return extractClaims(token).get("id", String.class);
-    }
-
-    // Http 요청 객체에서 부터 닉네임 추출
-    public String extractNickNameFromRequest(HttpServletRequest request) {
-        String accessToken = extractAccessToken(request);
-        return extractNickNameFromToken(accessToken);
-    }
-
-    // 토큰에서 닉네임 추출
-    public String extractNickNameFromToken(String token) {
-
-        return extractClaims(token).get("nickName", String.class);
     }
 
     // 리프레쉬 토큰 세션 레디스에 저장 메서드

--- a/src/main/java/org/com/dungeontalk/global/security/JwtService.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtService.java
@@ -97,9 +97,9 @@ public class JwtService {
     // 리프레쉬 토큰 세션 레디스에 저장 메서드
     public void saveRefreshTokenToSessionRedis(String memberId,String refreshToken) {
 
-        // log.info("length : {}",refreshToken.getBytes().length);
         String key = "refresh_token:" + memberId;
-        sessionRedis.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME);
+        sessionRedis.opsForValue().set(key, refreshToken);
+        //sessionRedis.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME); -> 문제의 원인
 
     }
 

--- a/src/main/java/org/com/dungeontalk/global/security/JwtService.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtService.java
@@ -99,7 +99,7 @@ public class JwtService {
 
         String key = "refresh_token:" + memberId;
         sessionRedis.opsForValue().set(key, refreshToken);
-        //sessionRedis.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME); -> 문제의 원인
+        //sessionRedis.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME); -> 문제의 원인, REFRESH_TOKEN_EXPIRATION_TIME
 
     }
 

--- a/src/main/java/org/com/dungeontalk/global/security/JwtService.java
+++ b/src/main/java/org/com/dungeontalk/global/security/JwtService.java
@@ -113,9 +113,9 @@ public class JwtService {
     }
 
     // 리프레쉬 토큰 세션 레디스에 저장 메서드
-    public void saveRefreshTokenToSessionRedis(Integer memberId,String refreshToken) {
+    public void saveRefreshTokenToSessionRedis(String memberId,String refreshToken) {
 
-        log.info("length : {}",refreshToken.getBytes().length);
+        // log.info("length : {}",refreshToken.getBytes().length);
         String key = "refresh_token:" + memberId;
         sessionRedis.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRATION_TIME);
 

--- a/src/main/java/org/com/dungeontalk/global/util/UuidV7Creator.java
+++ b/src/main/java/org/com/dungeontalk/global/util/UuidV7Creator.java
@@ -1,0 +1,10 @@
+package org.com.dungeontalk.global.util;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+
+public class UuidV7Creator {
+
+    public static String create() {
+        return UuidCreator.getTimeOrderedEpoch().toString(); // UUIDv7 유사
+    }
+}


### PR DESCRIPTION
# 요약
1. 로그인 API Valkey 이슈 해결 
2. Valkey 테스트 컨트롤러 3개 구현 (세션 테스팅)
3.  우선 Spring Security의 API 권한 Check는 모두 OPEN  -> 개발단계 끝나면 Close 할 예정

# 연관 이슈 및 Close 할 이슈 작성
Feat/#8

-- PR 시 다음과 같이 작성 
Feat/#8
close Feat/#8

# Pull Request 체크리스트

## TODO

- [ v ] 최종 결과물을 확인했는가?
- [ v ] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 로그인 및 로그아웃 API가 추가되었습니다.
  * Redis 기반 세션 데이터 테스트 및 조회 API가 추가되었습니다.
  * UUID v7 기반의 고유 식별자 자동 생성 기능이 도입되었습니다.
  * 회원 가입 시 중복 이름/닉네임 검사 기능이 추가되었습니다.

* **리팩터링**
  * 공통 엔티티(BaseEntity) 도입으로 회원 및 인증 엔티티 구조가 개선되었습니다.
  * 인증 관련 엔티티 및 레포지토리의 키 구조가 단순화되었습니다.

* **버그 수정 및 개선**
  * 모든 API가 개발 환경에서 인증 없이 접근 가능하도록 변경되었습니다.
  * 회원 가입 요청 처리 방식이 개선되었습니다.

* **문서화**
  * 일부 컨트롤러에 Javadoc 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->