### PR TITLE
[Feature] 퇴장 or 네트워크 끊김 시 접속자 수가 자동으로 줄어드는 기능 구현 + 채팅방 멤버 구현

### DIFF
--- a/src/main/java/org/com/dungeontalk/DungeontalkApplication.java
+++ b/src/main/java/org/com/dungeontalk/DungeontalkApplication.java
@@ -3,8 +3,10 @@ package org.com.dungeontalk;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @EnableJpaAuditing
+@EnableMongoAuditing
 @SpringBootApplication
 public class DungeontalkApplication {
 

--- a/src/main/java/org/com/dungeontalk/domain/chat/common/MessageType.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/common/MessageType.java
@@ -1,7 +1,7 @@
 package org.com.dungeontalk.domain.chat.common;
 
 public enum MessageType {
-    JOIN, TALK, LEAVE, CONNECTED_COUNT;
+    JOIN, TALK, LEAVE, CONNECTED_COUNT, PRESENCE;
 
     // @Enumerated 반영 안 되는 이슈 처리
     @Override

--- a/src/main/java/org/com/dungeontalk/domain/chat/common/Status.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/common/Status.java
@@ -1,0 +1,11 @@
+package org.com.dungeontalk.domain.chat.common;
+
+public enum Status {
+    ONLINE,
+    OFFLINE;
+
+    @Override
+    public String toString() {
+        return name();  // name() == "JOIN", "TALK" 등
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package org.com.dungeontalk.domain.chat.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.com.dungeontalk.domain.chat.dto.ChatMessageDto;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/chat")
+@RequestMapping("/v1/chat")
 @RequiredArgsConstructor
 public class ChatRoomController {
 
@@ -35,7 +36,7 @@ public class ChatRoomController {
      * 채팅방 생성
      */
     @PostMapping("/room")
-    public RsData<ChatRoomDto> createRoom(@RequestBody ChatRoomCreateRequestDto req) {
+    public RsData<ChatRoomDto> createRoom(@Valid @RequestBody ChatRoomCreateRequestDto req) {
         ChatRoomDto createdRoom = chatRoomService.createRoom(req);
         return RsData.of("200", "채팅방 생성 완료", createdRoom);
     }
@@ -64,7 +65,7 @@ public class ChatRoomController {
     @PostMapping("/room/{roomId}/join/{memberId}")
     public RsData<String> joinRoom(@PathVariable String roomId, @PathVariable String memberId) {
         chatRoomService.joinRoom(roomId, memberId);
-        return RsData.of("200", "채팅방 입장 성공", null);
+        return RsData.of("200", "채팅방 입장 성공", roomId);
     }
 
     /**
@@ -73,7 +74,7 @@ public class ChatRoomController {
     @DeleteMapping("/room/{roomId}/leave/{memberId}")
     public RsData<String> leaveRoom(@PathVariable String roomId, @PathVariable String memberId) {
         chatRoomService.leaveRoom(roomId, memberId);
-        return RsData.of("200", "채팅방 퇴장 성공", null);
+        return RsData.of("200", "채팅방 퇴장 성공", roomId);
     }
 
 
@@ -83,7 +84,7 @@ public class ChatRoomController {
     @PostMapping("/room/{roomId}/message")
     public RsData<ChatMessageDto> sendMessage(
         @PathVariable String roomId,
-        @RequestBody ChatMessageSendRequestDto msg) throws JsonProcessingException {
+        @Valid @RequestBody ChatMessageSendRequestDto msg) throws JsonProcessingException {
 
         if (msg == null || msg.getRoomId() == null) {
             return RsData.of("400", "요청 본문이 비어 있거나 roomId가 누락되었습니다.", null);

--- a/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatRoomMemberController.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatRoomMemberController.java
@@ -1,0 +1,41 @@
+package org.com.dungeontalk.domain.chat.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.com.dungeontalk.domain.chat.entity.ChatRoomMember;
+import org.com.dungeontalk.domain.chat.service.ChatRoomMemberService;
+import org.com.dungeontalk.domain.chat.service.ChatRoomService;
+import org.com.dungeontalk.global.rsData.RsData;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/chat/members")
+@RequiredArgsConstructor
+public class ChatRoomMemberController {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatRoomMemberService chatRoomMemberService;
+
+    @PostMapping("/{roomId}/join/{memberId}")
+    public RsData<String> join(@PathVariable String roomId, @PathVariable String memberId) {
+        chatRoomService.joinRoom(roomId, memberId);
+        return RsData.of("200", "멤버 입장 완료", null);
+    }
+
+    @PostMapping("/{roomId}/leave/{memberId}")
+    public RsData<String> leave(@PathVariable String roomId, @PathVariable String memberId) {
+        chatRoomService.leaveRoom(roomId, memberId);
+        return RsData.of("200", "멤버 퇴장 완료", null);
+    }
+
+    @GetMapping("/{roomId}/online")
+    public RsData<List<ChatRoomMember>> getOnlineMembers(@PathVariable String roomId) {
+        List<ChatRoomMember> members = chatRoomMemberService.getOnlineMembers(roomId);
+        return RsData.of("200", "온라인 멤버 조회 성공", members);
+    }
+
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatStompController.java
@@ -2,11 +2,13 @@ package org.com.dungeontalk.domain.chat.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.chat.dto.request.ChatMessageSendRequestDto;
 import org.com.dungeontalk.domain.chat.service.ChatMessageService;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -25,8 +27,10 @@ public class ChatStompController {
      * 이후 ChatMessageService가 메시지의 타입에 따라 처리(JOIN, LEAVE, TALK)
      */
     @MessageMapping("/chat/send") // /pub/chat/send
-    public void sendMessage(ChatMessageSendRequestDto dto) throws JsonProcessingException {
-        log.debug("STOMP 수신 메시지 처리 요청: {}", objectMapper.writeValueAsString(dto));
+    public void sendMessage(@Valid @Payload ChatMessageSendRequestDto dto) throws JsonProcessingException {
+        if (log.isDebugEnabled()) {
+            log.debug("STOMP 수신: {}", objectMapper.writeValueAsString(dto));
+        }
         chatMessageService.processMessage(dto);
     }
 

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatMessageDto.java
@@ -1,6 +1,8 @@
 package org.com.dungeontalk.domain.chat.dto;
 
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,10 +18,13 @@ public class ChatMessageDto {
     private String roomId;
     private String senderId;
     private String receiverId;
-    private String senderNickName;
+
+    @JsonProperty("senderNickname")
+    @JsonAlias("senderNickname")
+    private String senderNickname;
     private String content;
     private MessageType type;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     // 닉네임 포함 변환
     public static ChatMessageDto fromEntity(ChatMessage msg, String senderNickname) {
@@ -28,7 +33,7 @@ public class ChatMessageDto {
             .roomId(msg.getRoomId())
             .senderId(msg.getSenderId())
             .receiverId(msg.getReceiverId())
-            .senderNickName(senderNickname)
+            .senderNickname(senderNickname)
             .content(msg.getContent())
             .type(msg.getType())
             .createdAt(msg.getCreatedAt())

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatRoomDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatRoomDto.java
@@ -1,6 +1,6 @@
 package org.com.dungeontalk.domain.chat.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,17 +17,15 @@ public class ChatRoomDto {
     private String roomName;
     private String mode;
     private List<String> participants;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
 
     public static ChatRoomDto fromEntity(ChatRoom room) {
         return ChatRoomDto.builder()
             .id(room.getId())
-            .roomName(room.getRoomName())
             .roomType(room.getRoomType() != null ? room.getRoomType().name() : "UNKNOWN")
+            .roomName(room.getRoomName() != null ? room.getRoomName() : "UNKNOWN")
             .mode(room.getMode().name())
-            .participants(room.getParticipants())
             .createdAt(room.getCreatedAt())
             .updatedAt(room.getUpdatedAt())
             .build();

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/ConnectedCountMessageDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/ConnectedCountMessageDto.java
@@ -10,4 +10,12 @@ public class ConnectedCountMessageDto {
     private String roomId;
     private long connectedCount;
     private MessageType type;  // 항상 CONNECTED_COUNT
+
+    public static ConnectedCountMessageDto of(String roomId, long count) {
+        return ConnectedCountMessageDto.builder()
+            .roomId(roomId)
+            .connectedCount(count)
+            .type(MessageType.CONNECTED_COUNT)
+            .build();
+    }
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/PresenceMessageDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/PresenceMessageDto.java
@@ -1,0 +1,35 @@
+package org.com.dungeontalk.domain.chat.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.com.dungeontalk.domain.chat.common.MessageType;
+import org.com.dungeontalk.domain.chat.common.Status;
+
+@Getter
+@Builder
+public class PresenceMessageDto {
+
+    private String roomId;
+    private MessageType type;           // 항상 PRESENCE
+    private long connectedCount;
+    private List<MemberPresence> members;
+
+    @Getter
+    @Builder
+    public static class MemberPresence {
+        private String memberId;
+        private String nickname;
+        private Status status;          // ONLINE / OFFLINE
+    }
+
+    public static PresenceMessageDto of(String roomId, long count, List<MemberPresence> members) {
+        return PresenceMessageDto.builder()
+            .roomId(roomId)
+            .type(MessageType.PRESENCE)
+            .connectedCount(count)
+            .members(members)
+            .build();
+    }
+
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,6 +1,6 @@
 package org.com.dungeontalk.domain.chat.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,5 +12,5 @@ public class ChatMessageResponse {
     private String senderId;
     private String senderNickname;      // PostgreSQL에서 조회된 닉네임
     private String message;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatMessage.java
@@ -1,13 +1,16 @@
 package org.com.dungeontalk.domain.chat.entity;
 
-import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.com.dungeontalk.domain.chat.common.MessageType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "chat_messages")
@@ -21,6 +24,7 @@ public class ChatMessage {
     @Id
     private String messageId;    // UUID v7
 
+    @Indexed
     private String roomId;       // ★ 필수: 채팅방 ID (foreign key 역할)
     private String senderId;     // 보내는 사람
     private String receiverId;   // (선택) 받는 사람 (게임 채팅에서 사용)
@@ -28,7 +32,10 @@ public class ChatMessage {
 
     private MessageType type;     // JOIN, TALK, LEAVE
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
 
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatRoom.java
@@ -3,8 +3,8 @@ package org.com.dungeontalk.domain.chat.entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,8 +13,10 @@ import lombok.NoArgsConstructor;
 import org.com.dungeontalk.domain.chat.common.ChatMode;
 import org.com.dungeontalk.domain.chat.common.ChatRoomType;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection = "chat_rooms")
@@ -28,22 +30,24 @@ public class ChatRoom {
     @Id
     private String id;
 
-    private String roomName;
+    @Indexed
+    private String roomName;                 // ✅ 누락 보완
 
     @Enumerated(EnumType.STRING)
-    private ChatRoomType roomType;          // PLAYER or GAME
+    private ChatRoomType roomType;           // PLAYER or GAME
 
     @Enumerated(EnumType.STRING)
     private ChatMode mode;                  // SINGLE or MULTI
-    private List<String> participants;      // RDB 회원 ID
 
-//    @Builder.Default
-//    private List<ChatMessage> messages = new ArrayList<>();
+//    private List<String> participants;      // RDB 회원 ID
+
+    @Builder.Default
+    private List<ChatMessage> messages = new ArrayList<>();
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/entity/ChatRoomMember.java
@@ -1,0 +1,46 @@
+package org.com.dungeontalk.domain.chat.entity;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.com.dungeontalk.domain.chat.common.Status;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "chat_room_members")
+@CompoundIndex(name = "uniq_room_member", def = "{'roomId': 1, 'memberId': 1}", unique = true) // ✅ 중복 방지
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomMember {
+    @Id
+    private String id;          // MongoDB ObjectId
+
+    @Indexed
+    private String roomId;      // ChatRoom의 id
+
+    @Indexed
+    private String memberId;    // PostgreSQL Member의 id (연관)
+
+    @Enumerated(EnumType.STRING)
+    private Status status;      // ONLINE, OFFLINE
+
+    @CreatedDate
+    private Instant joinedAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+
+    private Instant leftAt;
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/repository/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package org.com.dungeontalk.domain.chat.repository;
 
+import java.util.List;
 import org.com.dungeontalk.domain.chat.entity.ChatMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,8 +11,13 @@ import org.springframework.stereotype.Repository;
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
     Page<ChatMessage> findByRoomId(String roomId, Pageable pageable);
-
     Page<ChatMessage> findByRoomIdOrderByCreatedAtDesc(String roomId, Pageable pageable);
+
+//    Slice<ChatMessage> findByRoomId(String roomId, Pageable pageable);              // 무한스크롤 최적 (total count x)
+
+    List<ChatMessage> findTop50ByRoomIdOrderByCreatedAtDesc(String roomId);         // 초기 로드용
+
+    long deleteByRoomId(String roomId); // 방 삭제 시 정리
 
 
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,0 +1,23 @@
+package org.com.dungeontalk.domain.chat.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.com.dungeontalk.domain.chat.common.Status;
+import org.com.dungeontalk.domain.chat.entity.ChatRoomMember;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomMemberRepository extends MongoRepository<ChatRoomMember, String> {
+    List<ChatRoomMember> findByRoomId(String roomId);
+
+    Optional<ChatRoomMember> findByRoomIdAndMemberId(String roomId, String memberId);
+
+    boolean existsByRoomIdAndMemberId(String roomId, String memberId);
+
+    long countByRoomIdAndStatus(String roomId, Status status);
+
+    List<ChatRoomMember> findByRoomIdAndStatus(String roomId, Status status);   // ONLINE 목록
+
+    long deleteByRoomId(String roomId);                                         // 방 제거 시 정리
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatMessageService.java
@@ -2,21 +2,17 @@ package org.com.dungeontalk.domain.chat.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.com.dungeontalk.domain.chat.common.MessageType;
 import org.com.dungeontalk.domain.chat.dto.ChatMessageDto;
-import org.com.dungeontalk.domain.chat.dto.ConnectedCountMessageDto;
 import org.com.dungeontalk.domain.chat.dto.request.ChatMessageSendRequestDto;
 import org.com.dungeontalk.domain.chat.dto.response.ChatMessageResponse;
 import org.com.dungeontalk.domain.chat.entity.ChatMessage;
-import org.com.dungeontalk.domain.chat.entity.ChatRoom;
 import org.com.dungeontalk.domain.chat.repository.ChatMessageRepository;
-import org.com.dungeontalk.domain.chat.repository.ChatRoomRepository;
 import org.com.dungeontalk.domain.member.entity.Member;
 import org.com.dungeontalk.domain.member.repository.MemberRepository;
 import org.com.dungeontalk.global.redis.ChatRoomMemberManager;
@@ -24,55 +20,73 @@ import org.com.dungeontalk.global.redis.RedisPublisher;
 import org.com.dungeontalk.global.util.UuidV7Creator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService {
 
-    private final SimpMessagingTemplate messagingTemplate;
-
     private final ChatMessageRepository chatMessageRepository;
-    private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
     private final RedisPublisher redisPublisher;
     private final ChatRoomMemberManager chatRoomMemberManager;
     private final ObjectMapper objectMapper;
 
-    private static final int MAX_ROOM_CAPACITY = 3;
+    // 참여자/인원/브로드캐스트는 ChatRoomService에 위임
+    private final ChatRoomService chatRoomService;;
 
     /**
      * STOMP 메시지 분기 처리 (Controller에서 단일 호출)
      */
-    public ChatMessageDto processMessage(ChatMessageSendRequestDto messageSendRequestDto) throws JsonProcessingException {
+    public ChatMessageDto processMessage(ChatMessageSendRequestDto dto) throws JsonProcessingException {
         ChatMessageDto chatMessageDto;
 
-        switch (messageSendRequestDto.getType()) {
-            case JOIN -> chatMessageDto = handleJoinMessage(messageSendRequestDto);
-            case LEAVE -> chatMessageDto = handleLeaveMessage(messageSendRequestDto);
-            case TALK -> chatMessageDto = handleTalkMessage(messageSendRequestDto);
-            default -> throw new IllegalArgumentException("유효하지 않은 메시지 타입");
-        }
+        if (dto.getType() == MessageType.JOIN) {
+            // 1) 입장 처리(인원 제한, Mongo/Redis, 접속수 브로드캐스트)
+            chatRoomService.joinRoom(dto.getRoomId(), dto.getSenderId());
 
-        if (messageSendRequestDto.getType().equals("TALK")) {
-            ChatMessageDto response = handleTalkMessage(messageSendRequestDto);
-
-            // ✅ 메시지 브로드캐스트 추가
-            messagingTemplate.convertAndSend(
-                "/sub/chat/room/" + messageSendRequestDto.getRoomId(),
-                response
-            );
+            // 2) 시스템 메시지 생성/저장
+            chatMessageDto = saveSystemMessage(dto.getRoomId(), dto.getSenderId(), MessageType.JOIN);
+        } else if (dto.getType() == MessageType.LEAVE) {
+            chatRoomService.leaveRoom(dto.getRoomId(), dto.getSenderId());
+            chatMessageDto = saveSystemMessage(dto.getRoomId(), dto.getSenderId(), MessageType.LEAVE);
+        } else if (dto.getType() == MessageType.TALK) {
+            chatMessageDto = handleTalkMessage(dto);
+        } else {
+            throw new IllegalArgumentException("유효하지 않은 메시지 타입");
         }
 
         // 메시지 브로드캐스트
         String json = objectMapper.writeValueAsString(chatMessageDto);
-        redisPublisher.publish(messageSendRequestDto.getRoomId(), json);
-
-        // 접속자 수 실시간 브로드캐스트
-        broadcastConnectedCount(messageSendRequestDto.getRoomId());
+        redisPublisher.publish(dto.getRoomId(), json);
 
         return chatMessageDto;
+    }
+
+    /**
+     * 메세지 저장
+     */
+    private ChatMessageDto saveSystemMessage(String roomId, String memberId, MessageType type) {
+        String member = memberRepository.findById(memberId)
+            .map(Member::getNickName)
+            .orElse("알 수 없음");
+
+        String content = (type == MessageType.JOIN)
+            ? member + "이 입장했습니다."
+            : member + "이 퇴장했습니다.";
+
+        ChatMessage msg = ChatMessage.builder()
+            .messageId(UuidV7Creator.create())
+            .roomId(roomId)
+            .senderId(memberId)
+            .content(content)
+            .type(type)
+            .createdAt(Instant.now())
+            .updatedAt(Instant.now())
+            .build();
+
+        ChatMessage saved = chatMessageRepository.save(msg);
+        return ChatMessageDto.fromEntity(saved, member);
     }
 
     /**
@@ -88,115 +102,33 @@ public class ChatMessageService {
             .receiverId(dto.getReceiverId())
             .content(dto.getContent())
             .type(MessageType.TALK)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(Instant.now())
+            .updatedAt(Instant.now())
             .build();
 
         ChatMessage saved = chatMessageRepository.save(message);
         return ChatMessageDto.fromEntity(saved, sender.getNickName());
     }
 
-    /**
-     * JOIN 메시지 처리
-     */
-    public ChatMessageDto handleJoinMessage(ChatMessageSendRequestDto dto) {
-        Member sender = getSender(dto);
-        String roomId = dto.getRoomId();
-        String nickName = sender.getNickName();
-
-        // Redis 인원 제한 확인
-        Set<String> currentUsers = chatRoomMemberManager.getUserList(roomId);
-        if (currentUsers.size() >= MAX_ROOM_CAPACITY) {
-            throw new IllegalStateException("채팅방 인원이 가득 찼습니다.");
-        }
-
-        // Redis에 접속자 등록
-        chatRoomMemberManager.addUser(roomId, nickName);
-
-        // MongoDB에 참여자 목록 추가
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("채팅방 없음"));
-        if (!room.getParticipants().contains(dto.getSenderId())) {
-            room.getParticipants().add(dto.getSenderId());
-            chatRoomRepository.save(room);
-        }
-
-        // 시스템 메시지 설정
-        dto.setSenderNickname(nickName);
-        dto.setContent(nickName + "님이 입장했습니다.");
-        dto.setType(MessageType.JOIN);
-
-        ChatMessage message = ChatMessage.builder()
-            .messageId(UuidV7Creator.create())
-            .roomId(roomId)
-            .senderId(dto.getSenderId())
-            .content(dto.getContent())
-            .type(MessageType.JOIN)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
-
-        ChatMessage saved = chatMessageRepository.save(message);
-        return ChatMessageDto.fromEntity(saved, nickName);
-    }
-
-    /**
-     * LEAVE 메시지 처리
-     */
-    public ChatMessageDto handleLeaveMessage(ChatMessageSendRequestDto dto) {
-        Member sender = getSender(dto);
-        String roomId = dto.getRoomId();
-        String nickName = sender.getNickName();
-
-        // Redis 접속자 제거
-        chatRoomMemberManager.removeUser(roomId, nickName);
-
-        // MongoDB 참여자 목록 제거
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("채팅방 없음"));
-        if (room.getParticipants().contains(dto.getSenderId())) {
-            room.getParticipants().remove(dto.getSenderId());
-            chatRoomRepository.save(room);
-        }
-
-        // 시스템 메시지 설정
-        dto.setSenderNickname(nickName);
-        dto.setContent(nickName + "님이 퇴장했습니다.");
-        dto.setType(MessageType.LEAVE);
-
-        ChatMessage message = ChatMessage.builder()
-            .messageId(UuidV7Creator.create())
-            .roomId(roomId)
-            .senderId(dto.getSenderId())
-            .content(dto.getContent())
-            .type(MessageType.LEAVE)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
-            .build();
-
-        ChatMessage saved = chatMessageRepository.save(message);
-        return ChatMessageDto.fromEntity(saved, nickName);
-    }
-
-    /**
-     * 실시간 접속자 수 브로드캐스트
-     */
-    public void broadcastConnectedCount(String roomId) {
-        try {
-            long count = chatRoomMemberManager.getUserCount(roomId);
-
-            ConnectedCountMessageDto broadcastMsg = ConnectedCountMessageDto.builder()
-                .roomId(roomId)
-                .connectedCount(count)
-                .type(MessageType.CONNECTED_COUNT)
-                .build();
-
-            String json = objectMapper.writeValueAsString(broadcastMsg);
-            redisPublisher.publish(roomId, json);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("접속자 수 전송 실패", e);
-        }
-    }
+//    /**
+//     * 실시간 접속자 수 브로드캐스트
+//     */
+//    public void broadcastConnectedCount(String roomId) {
+//        try {
+//            long count = chatRoomMemberManager.getUserCount(roomId);
+//
+//            ConnectedCountMessageDto broadcastMsg = ConnectedCountMessageDto.builder()
+//                .roomId(roomId)
+//                .connectedCount(count)
+//                .type(MessageType.CONNECTED_COUNT)
+//                .build();
+//
+//            String json = objectMapper.writeValueAsString(broadcastMsg);
+//            redisPublisher.publish(roomId, json);
+//        } catch (JsonProcessingException e) {
+//            throw new RuntimeException("접속자 수 전송 실패", e);
+//        }
+//    }
 
     /**
      * 채팅방 내 메시지 페이징 조회

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomMemberService.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomMemberService.java
@@ -1,0 +1,51 @@
+package org.com.dungeontalk.domain.chat.service;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.com.dungeontalk.domain.chat.common.Status;
+import org.com.dungeontalk.domain.chat.entity.ChatRoomMember;
+import org.com.dungeontalk.domain.chat.repository.ChatRoomMemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomMemberService {
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public void joinMember(String roomId, String memberId) {
+        ChatRoomMember member = chatRoomMemberRepository
+            .findByRoomIdAndMemberId(roomId, memberId)
+            .orElse(ChatRoomMember.builder()
+                .roomId(roomId)
+                .memberId(memberId)
+                .status(Status.ONLINE)
+                .joinedAt(Instant.now())
+                .build());
+
+
+        member.setStatus(Status.ONLINE);
+        member.setUpdatedAt(Instant.now());
+        chatRoomMemberRepository.save(member);
+    }
+
+    public void leaveMember(String roomId, String memberId) {
+        chatRoomMemberRepository.findByRoomIdAndMemberId(roomId, memberId)
+            .ifPresent(m -> {
+                m.setStatus(Status.OFFLINE);
+                m.setLeftAt(Instant.now());
+                chatRoomMemberRepository.save(m);
+            });
+    }
+
+    public List<ChatRoomMember> getOnlineMembers(String roomId) {
+        return chatRoomMemberRepository.findByRoomId(roomId)
+            .stream()
+            .filter(m -> m.getStatus() == Status.ONLINE)
+            .toList();
+    }
+
+    public long getOnlineCount(String roomId) {
+        return chatRoomMemberRepository.countByRoomIdAndStatus(roomId, Status.ONLINE);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomService.java
@@ -2,13 +2,22 @@ package org.com.dungeontalk.domain.chat.service;
 
 import static org.com.dungeontalk.domain.chat.dto.ChatRoomDto.fromEntity;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.com.dungeontalk.domain.chat.common.MessageType;
 import org.com.dungeontalk.domain.chat.dto.ChatRoomDto;
+import org.com.dungeontalk.domain.chat.dto.ConnectedCountMessageDto;
+import org.com.dungeontalk.domain.chat.dto.PresenceMessageDto;
 import org.com.dungeontalk.domain.chat.dto.request.ChatRoomCreateRequestDto;
 import org.com.dungeontalk.domain.chat.entity.ChatRoom;
+import org.com.dungeontalk.domain.chat.entity.ChatRoomMember;
 import org.com.dungeontalk.domain.chat.repository.ChatRoomRepository;
+import org.com.dungeontalk.domain.member.entity.Member;
+import org.com.dungeontalk.domain.member.repository.MemberRepository;
+import org.com.dungeontalk.global.redis.ChatRoomMemberManager;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,15 +25,21 @@ import org.springframework.stereotype.Service;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberService chatRoomMemberService;  // MongoDB
+    private final ChatRoomMemberManager chatRoomMemberManager;  // Redis
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final MemberRepository memberRepository;
+
+    private static final int MAX_ROOM_CAPACITY = 3;
 
     // 채팅방 생성
     public ChatRoomDto createRoom(ChatRoomCreateRequestDto req) {
         ChatRoom chatRoom = ChatRoom.builder()
-            .roomName(req.getRoomName())
             .roomType(req.getRoomType())
+            .roomName(req.getRoomName())
             .mode(req.getMode())
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .createdAt(Instant.now())
+            .updatedAt(Instant.now())
             .build();
 
         ChatRoom saved = chatRoomRepository.save(chatRoom);
@@ -48,23 +63,73 @@ public class ChatRoomService {
 
     // 참여자 입장
     public void joinRoom(String roomId, String memberId) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("채팅방 없음"));
-
-        if (!room.getParticipants().contains(memberId)) {
-            room.getParticipants().add(memberId);
-            chatRoomRepository.save(room);
+        // 인원 제한 (Redis 기준)
+        long current = chatRoomMemberManager.getUserCount(roomId);
+        if (current >= MAX_ROOM_CAPACITY) {
+            throw new IllegalStateException("채팅방 인원이 가득 찼습니다.");
         }
+
+        // 1. MongoDB 상태 ONLINE으로
+        chatRoomMemberService.joinMember(roomId, memberId);
+
+        // 2. Redis에 접속자 추가
+        chatRoomMemberManager.addUser(roomId, memberId);
+
+        // 3. 실시간 접속자 수 브로드캐스트
+        broadcastConnectedCount(roomId);
+
+        // 4. 현재 퇴장/재입장 상태 보여주기 - Presence 브로드캐스트
+        broadcastPresence(roomId);
     }
 
     // 참여자 퇴장
     public void leaveRoom(String roomId, String memberId) {
-        ChatRoom room = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new IllegalArgumentException("채팅방 없음"));
+        // 1. MongoDB 상태 OFFLINE으로
+        chatRoomMemberService.leaveMember(roomId, memberId);
 
-        room.getParticipants().remove(memberId);
-        chatRoomRepository.save(room);
+        // 2. Redis에서 접속자 제거
+        chatRoomMemberManager.removeUser(roomId, memberId);
+
+        // 3. 실시간 접속자 수 브로드캐스트
+        long count = chatRoomMemberManager.getUserCount(roomId);
+        ConnectedCountMessageDto msg = ConnectedCountMessageDto.builder()
+            .roomId(roomId)
+            .connectedCount(count)
+            .type(MessageType.CONNECTED_COUNT)
+            .build();
+        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, msg);
     }
 
+    // 접속자 수 파악
+    private void broadcastConnectedCount(String roomId) {
+        long count = chatRoomMemberManager.getUserCount(roomId);
+        messagingTemplate.convertAndSend(
+            "/sub/chat/room/" + roomId,
+            ConnectedCountMessageDto.of(roomId, count)
+        );
+    }
+
+    // 온라인에 접속 중인 멤버 조회
+    private void broadcastPresence(String roomId) {
+        List<ChatRoomMember> list = chatRoomMemberService.getOnlineMembers(roomId);
+        List<String> ids = list.stream().map(ChatRoomMember::getMemberId).toList();
+
+        Map<String,String> nickMap = memberRepository.findByIdIn(ids).stream()
+            .collect(java.util.stream.Collectors.toMap(Member::getId, Member::getNickName));
+
+        List<PresenceMessageDto.MemberPresence> members = list.stream()
+            .map(m -> PresenceMessageDto.MemberPresence.builder()
+                .memberId(m.getMemberId())
+                .nickname(nickMap.getOrDefault(m.getMemberId(), "알 수 없음"))
+                .status(m.getStatus())
+                .build())
+            .toList();
+
+        long count = chatRoomMemberManager.getUserCount(roomId);
+        messagingTemplate.convertAndSend(
+            "/sub/chat/room/" + roomId,
+            PresenceMessageDto.of(roomId, count, members)
+        );
+    }
 
 }

--- a/src/main/java/org/com/dungeontalk/global/config/ValkeyConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/ValkeyConfig.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -118,6 +119,12 @@ public class ValkeyConfig {
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
         return template;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(
+        @Qualifier("sessionRedisConnectionFactory") RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
     }
 
 }

--- a/src/main/java/org/com/dungeontalk/global/redis/ChatRoomMemberManager.java
+++ b/src/main/java/org/com/dungeontalk/global/redis/ChatRoomMemberManager.java
@@ -16,15 +16,14 @@ public class ChatRoomMemberManager {
     }
 
     // 유저 입장
-    public boolean addUser(String roomId, String nickName) {
-        String key = getRoomKey(roomId);
-        Long addedCount = redisTemplate.opsForSet().add(key, nickName);
-        return addedCount != null && addedCount > 0;
+    public boolean addUser(String roomId, String memberId) {
+        Long added = redisTemplate.opsForSet().add(getRoomKey(roomId), memberId);
+        return added != null && added > 0;
     }
 
     // 유저 퇴장
-    public void removeUser(String roomId, String nickName) {
-        redisTemplate.opsForSet().remove(getRoomKey(roomId), nickName);
+    public void removeUser(String roomId, String memberId) {
+        redisTemplate.opsForSet().remove(getRoomKey(roomId), memberId);
     }
 
     // 현재 유저 목록
@@ -35,7 +34,7 @@ public class ChatRoomMemberManager {
     // 현재 유저 수
     public Long getUserCount(String roomId) {
         Long size = redisTemplate.opsForSet().size(getRoomKey(roomId));
-        return size != null ? size.intValue() : 0L;
+        return size != null ? size : 0L;
     }
 
     // 채팅방 초기화

--- a/src/main/java/org/com/dungeontalk/global/redis/RedisSubscriber.java
+++ b/src/main/java/org/com/dungeontalk/global/redis/RedisSubscriber.java
@@ -1,7 +1,6 @@
 package org.com.dungeontalk.global.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -15,26 +14,40 @@ import org.springframework.stereotype.Service;
 public class RedisSubscriber implements MessageListener {
 
     private final SimpMessageSendingOperations messagingTemplate;
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ObjectWriter prettyPrinter = objectMapper.writerWithDefaultPrettyPrinter();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();      // JavaTimeModule 포함
+
+    // feature flag 예시
+    private final boolean enableAiChannel = false; // 환경변수/설정으로 주입 추천
 
     public void onMessage(Message message, byte[] pattern) {
         String payload = new String(message.getBody());
         String topic = new String(message.getChannel());
 
+        // chatroom.{roomId} 형태 가드
+        final String prefix = "chatroom.";
+        if (!topic.startsWith(prefix)) {
+            log.debug("Ignore message from topic: {}", topic);
+            return;
+        }
+        String roomId = topic.substring(prefix.length());
+
         try {
             Object json = objectMapper.readValue(payload, Object.class);
-            String prettyPayload = prettyPrinter.writeValueAsString(json);
-            log.info("📩 Redis pub/sub 수신 메시지:\n{}", prettyPayload);
+
+            // 로그 형식 간편하게 볼 수 있도록
+            if (log.isInfoEnabled()) {
+                log.info("📩 Redis 수신(roomId={}):\n{}",
+                    roomId, objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+            }
+
+            // 기본 채널도 '객체'로 쏜다
+            messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, json);
         } catch (Exception e) {
-            log.warn("Redis 메시지 JSON 파싱 실패: {}", payload, e);
+            log.warn("Redis 메시지 JSON 파싱 실패(roomId={}): {}", roomId, payload, e);
+
+            // 파싱 실패시 문자열로 전달
+            messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, payload);
         }
-
-        // roomId 추출 (chatroom.{roomId})
-        String roomId = topic.substring("chatroom.".length());
-
-        // 기존 채팅 시스템: 문자열로 전송 (기존 방식 유지)
-        messagingTemplate.convertAndSend("/sub/chat/room/" + roomId, payload);
         
         // AI 채팅 시스템: 객체로 전송 (새로 추가)
         try {

--- a/src/main/java/org/com/dungeontalk/global/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/org/com/dungeontalk/global/websocket/JwtHandshakeInterceptor.java
@@ -28,10 +28,26 @@ public class JwtHandshakeInterceptor extends HttpSessionHandshakeInterceptor {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             HttpServletRequest httpRequest = servletRequest.getServletRequest();
 
+            // 1) token, roomId를 쿼리에서 받기
             String token = httpRequest.getParameter("token");
+            String roomId = httpRequest.getParameter("roomId");
+
             log.info("🔥 WebSocket Handshake token: {}", token);
 
-            if (token == null) {
+            // Authorization 헤더도 허용하려면:
+            if ((token == null || token.isBlank())) {
+                String auth = httpRequest.getHeader("Authorization");
+                if (auth != null && auth.startsWith("Bearer ")) {
+                    token = auth.substring(7);
+                }
+            }
+
+            String masked = (token == null || token.length() < 8)
+                ? String.valueOf(token)
+                : token.substring(0, 4) + "..." + token.substring(token.length() - 4);
+            log.info("🔥 WS Handshake: token(masked)={}, roomId={}", masked, roomId);
+
+            if (token == null || roomId == null) {
                 log.warn("❌ WebSocket 인증 실패: 토큰 없음");
                 return false;
             }
@@ -46,8 +62,12 @@ public class JwtHandshakeInterceptor extends HttpSessionHandshakeInterceptor {
                 return false;
             }
 
-            log.info("✅ WebSocket 인증 성공");
+            // ✅ 세션 속성 저장 (Disconnect에서 사용)
+            String memberId = String.valueOf(jwtService.extractIdFromToken(token));
+            attributes.put("memberId", memberId);
+            attributes.put("roomId", roomId);
 
+            log.info("✅ WebSocket 인증 성공: memberId={}, roomId={}", memberId, roomId);
             return super.beforeHandshake(request, response, wsHandler, attributes);
         }
 

--- a/src/main/java/org/com/dungeontalk/global/websocket/WebSocketDisconnectHandler.java
+++ b/src/main/java/org/com/dungeontalk/global/websocket/WebSocketDisconnectHandler.java
@@ -1,0 +1,36 @@
+package org.com.dungeontalk.global.websocket;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.chat.service.ChatRoomService;
+import org.com.dungeontalk.global.redis.ChatRoomMemberManager;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketDisconnectHandler implements ApplicationListener<SessionDisconnectEvent> {
+
+    private final ChatRoomMemberManager chatRoomMemberManager;
+    private final ChatRoomService chatRoomService;
+
+    @Override
+    public void onApplicationEvent(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String memberId = (String) Objects.requireNonNull(accessor.getSessionAttributes()).get("memberId");
+        String roomId = (String) accessor.getSessionAttributes().get("roomId");
+
+        if (memberId != null && roomId != null) {
+            log.info("🚪WebSocket 연결 끊김 감지 → memberId: {}, roomId: {}", memberId, roomId);
+            chatRoomMemberManager.removeUser(roomId, memberId);
+            chatRoomService.leaveRoom(roomId, memberId);
+        } else {
+            log.warn("WebSocket 연결 끊김: memberId 또는 roomId 누락됨 (무시됨)");
+        }
+    }
+}

--- a/src/main/resources/static/chat-ssr-test.html
+++ b/src/main/resources/static/chat-ssr-test.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>던전톡 채팅 테스트 (SSR)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#f6f7fb;margin:0}
+    .wrap{max-width:1100px;margin:24px auto;padding:0 16px}
+    .grid{display:grid;grid-template-columns:320px 1fr;gap:16px}
+    .card{background:#fff;border-radius:14px;box-shadow:0 8px 24px rgba(0,0,0,.08)}
+    .card h2{margin:0;padding:14px 16px;border-bottom:1px solid #eee;font-size:16px}
+    .pad{padding:16px}
+    .row{display:flex;gap:8px;align-items:center;margin-bottom:8px}
+    input,select,button{padding:10px;border:1px solid #ddd;border-radius:10px;font-size:14px}
+    input[type=text]{flex:1}
+    button{background:#667eea;color:#fff;border:0;cursor:pointer}
+    button.gray{background:#9aa1b2}
+    button.red{background:#d64545}
+    .status{padding:10px;border-radius:10px;margin-bottom:10px;font-size:14px}
+    .ok{background:#e8f5e9;color:#2e7d32}.bad{background:#ffebee;color:#c62828}
+    .list{height:520px;overflow:auto;padding:16px}
+    .msg{margin:10px 0;padding:10px 12px;border-radius:10px;max-width:76%}
+    .me{background:#e3f2fd;margin-left:auto;text-align:right}
+    .other{background:#f3e5f5}
+    .sys{background:#fff3e0;text-align:center;max-width:100%}
+    .meta{font-size:12px;color:#666;margin-top:4px}
+    .count{font-weight:700}
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <div class="grid">
+    <div class="card">
+      <h2>설정 / 제어</h2>
+      <div class="pad">
+        <div id="conn" class="status bad">WS 끊김</div>
+
+        <div class="row"><label style="width:92px">닉네임</label><input id="nickname"/></div>
+        <div class="row"><label style="width:92px">방 이름</label><input id="roomName" value="테스트 방"/></div>
+        <div class="row"><label style="width:92px">Room Type</label><select id="roomType"><option>PLAYER</option><option>GAME</option></select></div>
+        <div class="row"><label style="width:92px">Mode</label><select id="mode"><option>SINGLE</option><option>MULTI</option></select></div>
+
+        <div class="row">
+          <input id="manualRoomId" placeholder="기존 방 ID 붙여넣기"/>
+          <button class="gray" onclick="useRoom()">설정</button>
+        </div>
+        <div class="row">
+          <button class="gray" onclick="copyInvite()">초대 링크 복사</button>
+          <button class="gray" onclick="loadRoomList()">방 목록 불러오기</button>
+        </div>
+
+        <div class="row">
+          <button onclick="createRoom()">방 생성</button>
+          <button class="gray" onclick="loadMessages()">메시지 로드</button>
+        </div>
+
+        <div class="row">
+          <button onclick="connectWS()">WS 연결</button>
+          <button class="gray" onclick="disconnectWS()">WS 해제</button>
+        </div>
+
+        <div class="row">
+          <button onclick="joinRoom()">입장</button>
+          <button class="red" onclick="leaveRoom()">퇴장</button>
+        </div>
+
+        <div class="row"><span>접속자 수: <span id="cc" class="count">0</span></span></div>
+        <div id="roomInfo" style="font-size:13px;color:#555;margin-top:8px"></div>
+        <div id="roomList" style="margin-top:12px;font-size:13px;color:#333"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>채팅</h2>
+      <div id="list" class="list"></div>
+      <div class="pad">
+        <div class="row">
+          <input id="input" placeholder="메시지를 입력하세요…" onkeypress="if(event.key==='Enter'){sendTalk();}"/>
+          <button onclick="sendTalk()">전송</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- SockJS/STOMP -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+<script>
+  // ====== DEBUG UTIL ======
+  const DEBUG = true;
+  const log = (...a)=> DEBUG && console.log('[CHAT]', ...a);
+  const info = (...a)=> DEBUG && console.info('[CHAT]', ...a);
+  const warn = (...a)=> DEBUG && console.warn('[CHAT]', ...a);
+  const err  = (...a)=> DEBUG && console.error('[CHAT]', ...a);
+
+  // 전역 에러/Promise 오류
+  window.addEventListener('error', ev => err('window.error', ev.error || ev.message));
+  window.addEventListener('unhandledrejection', ev => err('unhandledrejection', ev.reason));
+
+  // ===== 설정 =====
+  const WS_ENDPOINT = '/ws-chat';
+  const SUB_PATH = roomId => `/sub/chat/room/${roomId}`;
+  const PUB_PATH = '/pub/chat/send';
+
+  const API_CREATE_ROOM = '/api/chat/room';
+  const API_JOIN_ROOM = (roomId, memberId) => `/api/chat/room/${roomId}/join/${memberId}`;
+  const API_LEAVE_ROOM = (roomId, memberId) => `/api/chat/room/${roomId}/leave/${memberId}`;
+  const API_MESSAGES  = (roomId, page=0, size=30) => `/api/chat/room/${roomId}/messages?page=${page}&size=${size}`;
+  const API_ROOMS     = '/api/chat/room';
+
+  // ===== 상태 =====
+  let stomp = null;
+  let subscription = null;
+  let roomId = null;
+  let member = null;
+  let subscribed = false;
+
+  function authHeaders(){
+    const t = localStorage.getItem('authToken');
+    return t ? { 'Authorization': 'Bearer ' + t } : {};
+  }
+  function now(){ return new Date().toLocaleTimeString(); }
+  function addRow(cls, content, meta){
+    const box = document.getElementById('list');
+    const el = document.createElement('div');
+    el.className = 'msg ' + cls;
+    el.innerHTML = `<div>${content}</div>${meta?`<div class="meta">${meta}</div>`:''}`;
+    box.appendChild(el); box.scrollTop = box.scrollHeight;
+  }
+  function setConn(ok){
+    const el = document.getElementById('conn');
+    el.className = 'status ' + (ok?'ok':'bad');
+    el.textContent = ok?'WS 연결됨':'WS 끊김';
+  }
+  function setCount(n){ document.getElementById('cc').textContent = n; }
+  function escapeHtml(s){ return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/\n/g,'<br>'); }
+
+  // ===== 초기화 =====
+  (function init(){
+    const userStr = localStorage.getItem('currentUser');
+    const token = localStorage.getItem('authToken');
+    info('init: token present?', !!token, 'userStr:', userStr);
+    if(!userStr || !token){ alert('로그인이 필요합니다.'); location.href='/login-ssr-test.html'; return; }
+    member = JSON.parse(userStr);
+    document.getElementById('nickname').value = member.nickname || (member.id + '님');
+
+    const urlRoomId = new URLSearchParams(location.search).get('roomId');
+    if(urlRoomId){ setRoom(urlRoomId); addRow('sys', `기존 방 설정: ${roomId}`, now()); }
+    addRow('sys', '페이지 로드 완료', now());
+  })();
+
+  // ===== 방 선택/초대/목록 =====
+  function setRoom(id){
+    roomId = id;
+    document.getElementById('manualRoomId').value = id;
+    document.getElementById('roomInfo').textContent = `RoomID=${roomId}`;
+    info('setRoom', roomId);
+  }
+  function useRoom(){
+    const v = document.getElementById('manualRoomId').value.trim();
+    if(!v) return addRow('sys','방 ID를 입력하세요', now());
+    setRoom(v);
+    addRow('sys', `기존 방 설정: ${roomId}`, now());
+  }
+  function copyInvite(){
+    if(!roomId) return addRow('sys','먼저 방을 선택/생성하세요', now());
+    const link = `${location.origin}/chat-ssr-test.html?roomId=${encodeURIComponent(roomId)}`;
+    navigator.clipboard.writeText(link).then(()=>addRow('sys','초대 링크 복사됨', now()));
+  }
+  async function loadRoomList(){
+    try{
+      info('GET rooms');
+      const res = await fetch(API_ROOMS, { headers: authHeaders() });
+      info('GET rooms →', res.status);
+      if(!res.ok) throw new Error(await res.text());
+      const rs = await res.json();
+      const rooms = rs.data || [];
+      const box = document.getElementById('roomList');
+      if(!rooms.length){ box.innerHTML = '<div>열린 방이 없습니다.</div>'; return; }
+      box.innerHTML = rooms.map(r=>`
+        <div style="border:1px solid #eee;padding:8px;border-radius:10px;margin-bottom:6px">
+          <div><b>${escapeHtml(r.roomName || '(이름없음)')}</b></div>
+          <div style="font-size:12px;color:#666">ID: ${r.id} · ${r.roomType}/${r.mode}</div>
+          <div style="margin-top:6px"><button onclick="joinExisting('${r.id}')">참가</button></div>
+        </div>`).join('');
+    }catch(e){ err('rooms error', e); addRow('sys','방 목록 실패: '+e.message, now()); }
+  }
+  async function joinExisting(id){ setRoom(id); await ensureConnected(); await joinRoom(); }
+
+  // ===== 방 생성 =====
+  async function createRoom(){
+    const body = {
+      roomName: document.getElementById('roomName').value.trim() || '테스트 방',
+      roomType: document.getElementById('roomType').value,
+      mode: document.getElementById('mode').value,
+      participantIds: [member.id]
+    };
+    try{
+      info('POST create room', body);
+      const res = await fetch(API_CREATE_ROOM, { method:'POST', headers:{'Content-Type':'application/json', ...authHeaders()}, body: JSON.stringify(body) });
+      info('POST create →', res.status);
+      if(!res.ok) throw new Error(await res.text());
+      const rs = await res.json(); const data = rs.data || rs;
+      setRoom(data.id);
+      addRow('sys', `방 생성 성공: ${roomId}`, now());
+    }catch(e){ err('create error', e); addRow('sys','방 생성 실패: '+e.message, now()); }
+  }
+
+  // ===== WebSocket =====
+  async function ensureConnected(){
+    return new Promise((resolve)=>{
+      if(stomp?.connected){ subscribed = true; info('WS already connected'); return resolve(); }
+      if(!roomId){ addRow('sys','roomId가 없습니다', now()); return resolve(); }
+
+      const token = localStorage.getItem('authToken');
+      const url = `${WS_ENDPOINT}?token=${encodeURIComponent(token)}&roomId=${encodeURIComponent(roomId)}`;
+      info('WS connect', url);
+
+      const sock = new SockJS(url, null, { transports: ['websocket','xhr-streaming','xhr-polling'] });
+      sock.onopen = e => info('[SockJS.open]', e);
+      sock.onclose = e => warn('[SockJS.close]', e);
+      sock.onerror = e => err('[SockJS.error]', e);
+
+      stomp = Stomp.over(sock);
+      // STOMP 디버그 ON
+      stomp.debug = (str)=> DEBUG && console.debug('[STOMP]', str);
+
+      stomp.connect({}, _=>{
+        info('STOMP connected');
+        setConn(true);
+
+        // 중복 구독 방지
+        try{ subscription?.unsubscribe(); }catch(_){}
+        const dest = SUB_PATH(roomId);
+        subscription = stomp.subscribe(dest, msg=>{
+          info('[SUB]', 'dest=', dest, 'raw=', msg.body);
+          let p = msg.body;
+          try{ p = JSON.parse(msg.body); }catch(_){}
+          handleIncoming(p);
+        });
+        subscribed = true;
+        addRow('sys','WS 연결 성공', now());
+        resolve();
+      }, errFrame=>{
+        setConn(false);
+        err('STOMP connect error', errFrame);
+        addRow('sys','WS 연결 실패', now());
+        resolve();
+      });
+    });
+  }
+  function connectWS(){ ensureConnected(); }
+  function disconnectWS(){ try{ subscription?.unsubscribe(); }catch(_){ } try{ stomp?.disconnect(()=>setConn(false)); }catch(_){ } }
+
+  // ===== 입장 / 퇴장 =====
+  async function joinRoom(){
+    if(!roomId) return addRow('sys','roomId가 없습니다', now());
+    if(!subscribed) await ensureConnected();
+    try{
+      info('POST join', roomId, member.id);
+      const r = await fetch(API_JOIN_ROOM(roomId, member.id), { method:'POST', headers: authHeaders() });
+      info('POST join →', r.status);
+      if(!r.ok) throw new Error(await r.text());
+      const dto = { roomId, senderId: member.id, content:'', type:'JOIN' };
+      info('[PUB JOIN]', dto);
+      stomp?.send(PUB_PATH, {}, JSON.stringify(dto));
+      addRow('sys','방 입장 완료', now());
+    }catch(e){ err('join error', e); addRow('sys','입장 실패: '+e.message, now()); }
+  }
+
+  async function leaveRoom(){
+    if(!roomId) return;
+    try{
+      info('DELETE leave', roomId, member.id);
+      const r = await fetch(API_LEAVE_ROOM(roomId, member.id), { method:'DELETE', headers: authHeaders() });
+      info('DELETE leave →', r.status);
+      const dto = { roomId, senderId: member.id, content:'', type:'LEAVE' };
+      info('[PUB LEAVE]', dto);
+      stomp?.send(PUB_PATH, {}, JSON.stringify(dto));
+      addRow('sys','방 퇴장 완료', now());
+    }catch(e){ err('leave error', e); addRow('sys','퇴장 실패: '+e.message, now()); }
+  }
+
+  // ===== 메시지 =====
+  function sendTalk(){
+    const input = document.getElementById('input');
+    const text = (input.value || '').trim();
+    if(!text || !stomp?.connected || !roomId) return;
+    const dto = { roomId, senderId: member.id, content: text, type: 'TALK' };
+    info('[PUB TALK]', dto);
+    stomp.send(PUB_PATH, {}, JSON.stringify(dto));
+    input.value = '';
+  }
+
+  async function loadMessages(){
+    if(!roomId) return addRow('sys','방을 먼저 선택/생성하세요', now());
+    try{
+      info('GET messages', roomId);
+      const res = await fetch(API_MESSAGES(roomId, 0, 30), { headers: authHeaders() });
+      info('GET messages →', res.status);
+      if(!res.ok) throw new Error(await res.text());
+      const rs = await res.json();
+      const items = (rs.data?.content) || [];
+      addRow('sys', `최근 ${items.length}건 로드`, now());
+      items.slice().reverse().forEach(m=>{
+        const who = (m.senderId===member.id)?'me':'other';
+        const nick = m.senderNickname || m.senderNickName || (m.senderId===member.id?'나':'익명');
+        const text = m.message || m.content || '';
+        const when = new Date(m.createdAt).toLocaleTimeString();
+        addRow(who, escapeHtml(text), `${nick} · ${when}`);
+      });
+    }catch(e){ err('messages error', e); addRow('sys','메시지 로드 실패: '+e.message, now()); }
+  }
+
+  // ===== 수신 처리 =====
+  function handleIncoming(p){
+    if(typeof p === 'string'){ info('IN string', p); addRow('sys', p, now()); return; }
+    const t = p.type || p.messageType;
+    info('IN obj', p);
+
+    if(t === 'CONNECTED_COUNT'){ setCount(p.connectedCount ?? 0); return; }
+    if(t === 'PRESENCE'){ setCount(p.connectedCount ?? 0); return; }
+
+    const text = p.content || p.message || '';
+    if(t === 'TALK'){
+      const who = (p.senderId===member.id)?'me':'other';
+      const nick = p.senderNickname || p.senderNickName || '익명';
+      addRow(who, escapeHtml(text), `${nick} · ${now()}`);
+    }else if(t === 'JOIN' || t === 'LEAVE'){
+      addRow('sys', escapeHtml(text), now());
+    }else{
+      addRow('sys', JSON.stringify(p), now());
+    }
+  }
+
+  // 창 닫기 정리
+  window.addEventListener('beforeunload', ()=>{
+    try{ if(roomId && member?.id){ navigator.sendBeacon(API_LEAVE_ROOM(roomId, member.id)); } }catch(_){}
+    try{ subscription?.unsubscribe(); stomp?.disconnect(()=>{}); }catch(_){}
+  });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/chat-ssr-test.html
+++ b/src/main/resources/static/chat-ssr-test.html
@@ -84,74 +84,69 @@
   </div>
 </div>
 
-<!-- SockJS/STOMP -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
 <script>
-  // ====== DEBUG UTIL ======
+  // ===== DEBUG =====
   const DEBUG = true;
   const log = (...a)=> DEBUG && console.log('[CHAT]', ...a);
   const info = (...a)=> DEBUG && console.info('[CHAT]', ...a);
   const warn = (...a)=> DEBUG && console.warn('[CHAT]', ...a);
   const err  = (...a)=> DEBUG && console.error('[CHAT]', ...a);
+  window.addEventListener('error', e=>err('window.error', e.error||e.message));
+  window.addEventListener('unhandledrejection', e=>err('unhandledrejection', e.reason));
 
-  // 전역 에러/Promise 오류
-  window.addEventListener('error', ev => err('window.error', ev.error || ev.message));
-  window.addEventListener('unhandledrejection', ev => err('unhandledrejection', ev.reason));
-
-  // ===== 설정 =====
+  // ===== API PATHS (v1) =====
   const WS_ENDPOINT = '/ws-chat';
-  const SUB_PATH = roomId => `/sub/chat/room/${roomId}`;
+  const SUB_PATH = id => `/sub/chat/room/${id}`;
   const PUB_PATH = '/pub/chat/send';
 
-  const API_CREATE_ROOM = '/api/chat/room';
-  const API_JOIN_ROOM = (roomId, memberId) => `/api/chat/room/${roomId}/join/${memberId}`;
-  const API_LEAVE_ROOM = (roomId, memberId) => `/api/chat/room/${roomId}/leave/${memberId}`;
-  const API_MESSAGES  = (roomId, page=0, size=30) => `/api/chat/room/${roomId}/messages?page=${page}&size=${size}`;
-  const API_ROOMS     = '/api/chat/room';
+  const API_CREATE_ROOM = '/v1/chat/room';
+  const API_JOIN_ROOM   = (rid, mid)=> `/v1/chat/room/${rid}/join/${mid}`;
+  const API_LEAVE_ROOM  = (rid, mid)=> `/v1/chat/room/${rid}/leave/${mid}`;
+  const API_MESSAGES    = (rid, p=0, s=30)=> `/v1/chat/room/${rid}/messages?page=${p}&size=${s}`;
+  const API_ROOMS       = '/v1/chat/room';
 
-  // ===== 상태 =====
-  let stomp = null;
-  let subscription = null;
-  let roomId = null;
-  let member = null;
-  let subscribed = false;
+  // ===== STATE =====
+  let stomp = null, subscription = null;
+  let roomId = null, member = null, subscribed = false;
 
-  function authHeaders(){
+  const authHeaders = ()=> {
     const t = localStorage.getItem('authToken');
-    return t ? { 'Authorization': 'Bearer ' + t } : {};
-  }
-  function now(){ return new Date().toLocaleTimeString(); }
-  function addRow(cls, content, meta){
+    return t ? { Authorization: 'Bearer '+t } : {};
+  };
+  const now = ()=> new Date().toLocaleTimeString();
+  const escapeHtml = s => (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/\n/g,'<br>');
+
+  const setConn = ok => {
+    const el = document.getElementById('conn');
+    el.className = 'status ' + (ok?'ok':'bad');
+    el.textContent = ok?'WS 연결됨':'WS 끊김';
+  };
+  const setCount = n => document.getElementById('cc').textContent = n;
+  const addRow = (cls, content, meta) => {
     const box = document.getElementById('list');
     const el = document.createElement('div');
     el.className = 'msg ' + cls;
     el.innerHTML = `<div>${content}</div>${meta?`<div class="meta">${meta}</div>`:''}`;
     box.appendChild(el); box.scrollTop = box.scrollHeight;
-  }
-  function setConn(ok){
-    const el = document.getElementById('conn');
-    el.className = 'status ' + (ok?'ok':'bad');
-    el.textContent = ok?'WS 연결됨':'WS 끊김';
-  }
-  function setCount(n){ document.getElementById('cc').textContent = n; }
-  function escapeHtml(s){ return (s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/\n/g,'<br>'); }
+  };
 
-  // ===== 초기화 =====
+  // ===== INIT =====
   (function init(){
     const userStr = localStorage.getItem('currentUser');
     const token = localStorage.getItem('authToken');
-    info('init: token present?', !!token, 'userStr:', userStr);
-    if(!userStr || !token){ alert('로그인이 필요합니다.'); location.href='/login-ssr-test.html'; return; }
+    info('init: token?', !!token, 'userStr?', !!userStr);
+    if(!userStr || !token){ alert('로그인이 필요합니다.'); location.href='/login-chat-test.html'; return; }
     member = JSON.parse(userStr);
-    document.getElementById('nickname').value = member.nickname || (member.id + '님');
+    document.getElementById('nickname').value = member.nickname || (member.id+'님');
 
     const urlRoomId = new URLSearchParams(location.search).get('roomId');
     if(urlRoomId){ setRoom(urlRoomId); addRow('sys', `기존 방 설정: ${roomId}`, now()); }
-    addRow('sys', '페이지 로드 완료', now());
+    addRow('sys','페이지 로드 완료', now());
   })();
 
-  // ===== 방 선택/초대/목록 =====
+  // ===== ROOM UTILS =====
   function setRoom(id){
     roomId = id;
     document.getElementById('manualRoomId').value = id;
@@ -160,7 +155,7 @@
   }
   function useRoom(){
     const v = document.getElementById('manualRoomId').value.trim();
-    if(!v) return addRow('sys','방 ID를 입력하세요', now());
+    if(!v) return addRow('sys', '방 ID를 입력하세요', now());
     setRoom(v);
     addRow('sys', `기존 방 설정: ${roomId}`, now());
   }
@@ -185,11 +180,11 @@
           <div style="font-size:12px;color:#666">ID: ${r.id} · ${r.roomType}/${r.mode}</div>
           <div style="margin-top:6px"><button onclick="joinExisting('${r.id}')">참가</button></div>
         </div>`).join('');
-    }catch(e){ err('rooms error', e); addRow('sys','방 목록 실패: '+e.message, now()); }
+    }catch(e){ err('rooms error', e); addRow('sys', '방 목록 실패: '+e.message, now()); }
   }
   async function joinExisting(id){ setRoom(id); await ensureConnected(); await joinRoom(); }
 
-  // ===== 방 생성 =====
+  // ===== CREATE ROOM =====
   async function createRoom(){
     const body = {
       roomName: document.getElementById('roomName').value.trim() || '테스트 방',
@@ -198,8 +193,10 @@
       participantIds: [member.id]
     };
     try{
-      info('POST create room', body);
-      const res = await fetch(API_CREATE_ROOM, { method:'POST', headers:{'Content-Type':'application/json', ...authHeaders()}, body: JSON.stringify(body) });
+      info('POST create', body);
+      const res = await fetch(API_CREATE_ROOM, {
+        method:'POST', headers:{'Content-Type':'application/json', ...authHeaders()}, body: JSON.stringify(body)
+      });
       info('POST create →', res.status);
       if(!res.ok) throw new Error(await res.text());
       const rs = await res.json(); const data = rs.data || rs;
@@ -208,7 +205,7 @@
     }catch(e){ err('create error', e); addRow('sys','방 생성 실패: '+e.message, now()); }
   }
 
-  // ===== WebSocket =====
+  // ===== WS =====
   async function ensureConnected(){
     return new Promise((resolve)=>{
       if(stomp?.connected){ subscribed = true; info('WS already connected'); return resolve(); }
@@ -218,43 +215,37 @@
       const url = `${WS_ENDPOINT}?token=${encodeURIComponent(token)}&roomId=${encodeURIComponent(roomId)}`;
       info('WS connect', url);
 
-      const sock = new SockJS(url, null, { transports: ['websocket','xhr-streaming','xhr-polling'] });
-      sock.onopen = e => info('[SockJS.open]', e);
-      sock.onclose = e => warn('[SockJS.close]', e);
-      sock.onerror = e => err('[SockJS.error]', e);
+      const sock = new SockJS(url, null, {transports:['websocket','xhr-streaming','xhr-polling']});
+      sock.onopen = e=>info('[SockJS.open]', e);
+      sock.onclose = e=>warn('[SockJS.close]', e);
+      sock.onerror = e=>err('[SockJS.error]', e);
 
       stomp = Stomp.over(sock);
-      // STOMP 디버그 ON
-      stomp.debug = (str)=> DEBUG && console.debug('[STOMP]', str);
+      stomp.debug = s=> DEBUG && console.debug('[STOMP]', s);
 
       stomp.connect({}, _=>{
         info('STOMP connected');
         setConn(true);
 
-        // 중복 구독 방지
         try{ subscription?.unsubscribe(); }catch(_){}
         const dest = SUB_PATH(roomId);
         subscription = stomp.subscribe(dest, msg=>{
           info('[SUB]', 'dest=', dest, 'raw=', msg.body);
-          let p = msg.body;
-          try{ p = JSON.parse(msg.body); }catch(_){}
+          let p = msg.body; try{ p = JSON.parse(msg.body); }catch(_){}
           handleIncoming(p);
         });
         subscribed = true;
         addRow('sys','WS 연결 성공', now());
         resolve();
       }, errFrame=>{
-        setConn(false);
-        err('STOMP connect error', errFrame);
-        addRow('sys','WS 연결 실패', now());
-        resolve();
+        setConn(false); err('STOMP connect error', errFrame); addRow('sys','WS 연결 실패', now()); resolve();
       });
     });
   }
   function connectWS(){ ensureConnected(); }
-  function disconnectWS(){ try{ subscription?.unsubscribe(); }catch(_){ } try{ stomp?.disconnect(()=>setConn(false)); }catch(_){ } }
+  function disconnectWS(){ try{ subscription?.unsubscribe(); }catch(_){ } try{ stomp?.disconnect(()=>setConn(false)); }catch(_){} }
 
-  // ===== 입장 / 퇴장 =====
+  // ===== JOIN / LEAVE =====
   async function joinRoom(){
     if(!roomId) return addRow('sys','roomId가 없습니다', now());
     if(!subscribed) await ensureConnected();
@@ -283,10 +274,10 @@
     }catch(e){ err('leave error', e); addRow('sys','퇴장 실패: '+e.message, now()); }
   }
 
-  // ===== 메시지 =====
+  // ===== TALK / MESSAGES =====
   function sendTalk(){
     const input = document.getElementById('input');
-    const text = (input.value || '').trim();
+    const text = (input.value||'').trim();
     if(!text || !stomp?.connected || !roomId) return;
     const dto = { roomId, senderId: member.id, content: text, type: 'TALK' };
     info('[PUB TALK]', dto);
@@ -314,7 +305,7 @@
     }catch(e){ err('messages error', e); addRow('sys','메시지 로드 실패: '+e.message, now()); }
   }
 
-  // ===== 수신 처리 =====
+  // ===== INCOMING =====
   function handleIncoming(p){
     if(typeof p === 'string'){ info('IN string', p); addRow('sys', p, now()); return; }
     const t = p.type || p.messageType;
@@ -335,7 +326,7 @@
     }
   }
 
-  // 창 닫기 정리
+  // ===== UNLOAD =====
   window.addEventListener('beforeunload', ()=>{
     try{ if(roomId && member?.id){ navigator.sendBeacon(API_LEAVE_ROOM(roomId, member.id)); } }catch(_){}
     try{ subscription?.unsubscribe(); stomp?.disconnect(()=>{}); }catch(_){}

--- a/src/main/resources/static/login-chat-test.html
+++ b/src/main/resources/static/login-chat-test.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <title>던전톡 로그인 테스트 (SSR)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#f6f7fb;margin:0;display:flex;min-height:100vh;align-items:center;justify-content:center}
+    .card{background:#fff;border-radius:14px;box-shadow:0 8px 24px rgba(0,0,0,.08);width:380px;padding:26px}
+    h1{margin:0 0 12px;font-size:20px}
+    .muted{color:#666;margin:0 0 16px}
+    label{font-weight:600;font-size:13px;display:block;margin:10px 0 6px}
+    input{width:100%;padding:12px;border:1px solid #ddd;border-radius:10px;font-size:15px}
+    button{width:100%;padding:12px;border:0;border-radius:10px;background:#667eea;color:#fff;font-weight:700;cursor:pointer;margin-top:12px}
+    button.secondary{background:#28a745}
+    .msg{margin-top:12px;font-size:14px}
+    .error{color:#d32f2f}.success{color:#2e7d32}
+    .hint{margin-top:16px;background:#f8f9fb;border:1px dashed #ddd;border-radius:10px;padding:10px;font-size:13px;color:#555}
+    .row{display:flex;gap:10px}
+  </style>
+</head>
+<body>
+<div class="card">
+  <h1>🎲 던전톡 로그인</h1>
+  <p class="muted">SSR 채팅 테스트를 위한 간단 로그인</p>
+
+  <label>사용자 ID</label>
+  <input id="userId" value="testuser1" />
+
+  <label>비밀번호</label>
+  <input id="password" type="password" value="password123" />
+
+  <button onclick="login()">로그인</button>
+  <button class="secondary" onclick="register()">회원가입(테스트)</button>
+
+  <div id="message" class="msg"></div>
+
+  <div class="hint">
+    <div><b>샘플 계정</b></div>
+    <div>testuser1 / password123</div>
+    <div>testuser2 / password123</div>
+    <div>gm / gmpassword</div>
+  </div>
+</div>
+
+<script>
+  const DEBUG = true;
+  const log = (...a)=> DEBUG && console.log('[AUTH]', ...a);
+  const err = (...a)=> DEBUG && console.error('[AUTH]', ...a);
+
+  const API_LOGIN = '/v1/auth/login';
+  const API_REGISTER = '/v1/member/register';
+  const NEXT_PAGE = '/chat-ssr-test.html';
+
+  function show(msg, type='success'){
+    const el = document.getElementById('message');
+    el.className = 'msg ' + (type==='error'?'error':'success');
+    el.textContent = msg;
+  }
+
+  async function register(){
+    const name = document.getElementById('userId').value.trim();
+    const password = document.getElementById('password').value.trim();
+    if(!name || !password) return show('ID/비밀번호를 입력하세요','error');
+
+    try{
+      log('POST register', name);
+      const res = await fetch(API_REGISTER, {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ name, nickName: name+'님', password })
+      });
+      log('POST register →', res.status);
+      if(!res.ok){ return show('회원가입 실패: '+(await res.text()), 'error'); }
+      show('회원가입 성공! 이제 로그인하세요.');
+    }catch(e){ err('register error', e); show('회원가입 오류: '+e.message, 'error'); }
+  }
+
+  async function login(){
+    const name = document.getElementById('userId').value.trim();
+    const password = document.getElementById('password').value.trim();
+    if(!name || !password) return show('ID/비밀번호를 입력하세요','error');
+
+    try{
+      log('POST login', name);
+      const res = await fetch(API_LOGIN, {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ name, password })
+      });
+      log('POST login →', res.status);
+      if(!res.ok){ return show('로그인 실패: '+(await res.text()), 'error'); }
+
+      const body = await res.json();
+      const data = body.data || body;
+      log('login body', body);
+
+      // 서버 응답 키에 맞춰 저장
+      localStorage.setItem('authToken', data.accessToken);
+      localStorage.setItem('currentUser', JSON.stringify({ id: data.memberId, nickname: name+'님' }));
+      show('로그인 성공! 채팅 페이지로 이동합니다.');
+      setTimeout(()=>location.href = NEXT_PAGE, 900);
+    }catch(e){ err('login error', e); show('로그인 오류: '+e.message,'error'); }
+  }
+</script>
+</body>
+</html>

--- a/src/main/resources/static/login-chat-test.html
+++ b/src/main/resources/static/login-chat-test.html
@@ -16,7 +16,6 @@
     .msg{margin-top:12px;font-size:14px}
     .error{color:#d32f2f}.success{color:#2e7d32}
     .hint{margin-top:16px;background:#f8f9fb;border:1px dashed #ddd;border-radius:10px;padding:10px;font-size:13px;color:#555}
-    .row{display:flex;gap:10px}
   </style>
 </head>
 <body>
@@ -48,6 +47,7 @@
   const log = (...a)=> DEBUG && console.log('[AUTH]', ...a);
   const err = (...a)=> DEBUG && console.error('[AUTH]', ...a);
 
+  // (인증 API는 기존 경로 유지 가정)
   const API_LOGIN = '/v1/auth/login';
   const API_REGISTER = '/v1/member/register';
   const NEXT_PAGE = '/chat-ssr-test.html';
@@ -91,11 +91,9 @@
 
       const body = await res.json();
       const data = body.data || body;
-      log('login body', body);
-
-      // 서버 응답 키에 맞춰 저장
       localStorage.setItem('authToken', data.accessToken);
       localStorage.setItem('currentUser', JSON.stringify({ id: data.memberId, nickname: name+'님' }));
+
       show('로그인 성공! 채팅 페이지로 이동합니다.');
       setTimeout(()=>location.href = NEXT_PAGE, 900);
     }catch(e){ err('login error', e); show('로그인 오류: '+e.message,'error'); }


### PR DESCRIPTION
# 요약
- [x] 🔥 WebSocketDisconnectHandler 추가
- [x] 🔥 RedisSubscriber 추가
- [x] 🔥 ChatRoomMember 추가(채팅방 멤버만 별도로 관리하도록 진행)
- [x] 🔥 채팅방 관련 로직 전면 수정(현재 실시간 채팅방 멤버 업데이트 안 됨)
- [x] 🔥 채팅방 멤버별 Online / Offline 구분
- [x] 🔥 채팅파트, LocalDateTime -> Instant 로 변경
- [x] 🔥 MongoDB 엔티티에 어노테이션 적용 가능하도록 추가 

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#21
close #21

# Pull Request 체크리스트
## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 실시간 접속자 수·프레즌스 방송 및 온라인 멤버 조회 API 추가
  - 멤버 입장/퇴장 전용 엔드포인트 추가, 웹소켓 연결/해제 처리 강화, JWT 핸드셰이크 개선
  - 채팅 초기 메시지 상위 50건 조회, 방 삭제 시 메시지 정리
  - 테스트용 로그인/채팅 HTML 페이지 추가
- Refactor
  - Redis 기반 브로드캐스트/프레즌스 전환, MongoDB 감사 기능 활성화
  - 시간 타입 Instant로 통일, 필드명 일관화, 요청 유효성 검증 추가
  - 응답에 roomId 포함
- Breaking Changes
  - REST 경로 /api/chat → /v1/chat
  - 타임스탬프 타입 LocalDateTime → Instant 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->