### PR TITLE
 [Refactor] AI 채팅, 매칭, 실시간 채팅 시스템 통합 및 아키텍처 개선

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/aichat/controller/AiResponseController.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/controller/AiResponseController.java
@@ -6,6 +6,7 @@ import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
 import org.com.dungeontalk.domain.aichat.dto.request.AiErrorRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.AiGenerateRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.AiMessageSaveRequest;
+import org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.AiResponseRequest;
 import org.com.dungeontalk.domain.aichat.dto.response.AiGameMessageResponse;
 import org.com.dungeontalk.domain.aichat.dto.response.ProcessingStatusResponse;
@@ -186,11 +187,10 @@ public class AiResponseController {
         return RsData.of("500-1", errorMessage, null);
     }
 
-    private org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest createErrorSystemMessage(
+    private AiGameMessageSendRequest createErrorSystemMessage(
             String roomId, AiErrorRequest request) {
         
-        org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest systemMessage = 
-                new org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest();
+        AiGameMessageSendRequest systemMessage = new AiGameMessageSendRequest();
         
         systemMessage.setAiGameRoomId(roomId);
         systemMessage.setGameId(request.getGameId());

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiGameMessageSendRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiGameMessageSendRequest.java
@@ -1,6 +1,9 @@
 package org.com.dungeontalk.domain.aichat.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.com.dungeontalk.domain.aichat.common.AiMessageType;
 
@@ -10,6 +13,9 @@ import jakarta.validation.constraints.Positive;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class AiGameMessageSendRequest {
 
     @NotBlank(message = "AI 게임방 ID는 필수입니다")

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
@@ -9,6 +9,7 @@ import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
 import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
 import org.com.dungeontalk.domain.aichat.common.AiMessageType;
 import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.common.UnifiedMessageType;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
 import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
@@ -152,13 +153,17 @@ public class AiGameRoomServiceAdapter implements RoomService {
             throw new IllegalArgumentException("AI 게임 메시지가 아닙니다: " + request.getRoomType());
         }
         
-        // UnifiedMessageRequest -> AiGameMessageSendRequest 변환
-        AiGameMessageSendRequest aiRequest = new AiGameMessageSendRequest();
-        aiRequest.setAiGameRoomId(request.getAiGameRoomId() != null ? request.getAiGameRoomId() : request.getRoomId());
-        aiRequest.setSenderId(request.getSenderId());
-        aiRequest.setContent(request.getContent());
-        aiRequest.setMessageType(mapToAiMessageType(request.getMessageType()));
-        aiRequest.setSenderNickname(request.getSenderId()); // 기본값으로 ID 사용
+        // UnifiedMessageRequest -> AiGameMessageSendRequest 변환 (빌더 패턴 사용)
+        AiGameMessageSendRequest aiRequest = AiGameMessageSendRequest.builder()
+                .aiGameRoomId(request.getAiGameRoomId() != null ? request.getAiGameRoomId() : request.getRoomId())
+                .gameId(request.getAiGameRoomId() != null ? request.getAiGameRoomId() : request.getRoomId()) // gameId도 같은 값으로 설정
+                .senderId(request.getSenderId())
+                .content(request.getContent())
+                .messageType(mapToAiMessageType(request.getMessageType()))
+                .senderNickname(request.getSenderId()) // 기본값으로 ID 사용
+                .turnNumber(request.getTurnNumber() != null ? request.getTurnNumber() : 1) // 기본값 1
+                .messageOrder(0) // 기본값 0
+                .build();
         
         // 기존 AI 메시지 서비스 호출
         try {
@@ -174,12 +179,16 @@ public class AiGameRoomServiceAdapter implements RoomService {
     public void sendSystemMessage(String roomId, String message) {
         log.debug("AI 게임룸 시스템 메시지 전송 (어댑터): roomId={}", roomId);
         
-        AiGameMessageSendRequest systemRequest = new AiGameMessageSendRequest();
-        systemRequest.setAiGameRoomId(roomId);
-        systemRequest.setSenderId("SYSTEM");
-        systemRequest.setContent(message);
-        systemRequest.setMessageType(AiMessageType.SYSTEM);
-        systemRequest.setSenderNickname("SYSTEM");
+        AiGameMessageSendRequest systemRequest = AiGameMessageSendRequest.builder()
+                .aiGameRoomId(roomId)
+                .gameId(roomId) // gameId도 같은 값으로 설정
+                .senderId("SYSTEM")
+                .content(message)
+                .messageType(AiMessageType.SYSTEM)
+                .senderNickname("SYSTEM")
+                .turnNumber(1) // 기본값 1
+                .messageOrder(0) // 기본값 0
+                .build();
         
         try {
             aiGameMessageService.processMessage(systemRequest);
@@ -244,8 +253,7 @@ public class AiGameRoomServiceAdapter implements RoomService {
     /**
      * 통합 메시지 타입을 AI 메시지 타입으로 매핑
      */
-    private AiMessageType mapToAiMessageType(
-            org.com.dungeontalk.domain.room.common.UnifiedMessageType unifiedType) {
+    private AiMessageType mapToAiMessageType(UnifiedMessageType unifiedType) {
         
         switch (unifiedType) {
             case USER:

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
@@ -3,7 +3,11 @@ package org.com.dungeontalk.domain.aichat.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomCreateRequest;
+import org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest;
+import org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest;
 import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
+import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
+import org.com.dungeontalk.domain.aichat.common.AiMessageType;
 import org.com.dungeontalk.domain.room.common.RoomType;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
@@ -58,8 +62,7 @@ public class AiGameRoomServiceAdapter implements RoomService {
             for (String participantId : request.getParticipantIds()) {
                 if (!participantId.equals(request.getCreatorId())) {
                     try {
-                        org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest joinReq = 
-                            new org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest();
+                        AiGameRoomJoinRequest joinReq = new AiGameRoomJoinRequest();
                         joinReq.setAiGameRoomId(aiResponse.getId());
                         joinReq.setParticipantId(participantId);
                         joinReq.setParticipantNickname(participantId); // 기본값으로 ID 사용
@@ -109,8 +112,7 @@ public class AiGameRoomServiceAdapter implements RoomService {
     public UnifiedRoomResponse joinRoom(String roomId, String memberId) {
         log.info("AI 게임룸 참여 (어댑터): roomId={}, memberId={}", roomId, memberId);
         
-        org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest joinRequest = 
-            new org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest();
+        AiGameRoomJoinRequest joinRequest = new AiGameRoomJoinRequest();
         joinRequest.setAiGameRoomId(roomId);
         joinRequest.setParticipantId(memberId);
         joinRequest.setParticipantNickname(memberId); // 기본값으로 ID 사용
@@ -151,9 +153,7 @@ public class AiGameRoomServiceAdapter implements RoomService {
         }
         
         // UnifiedMessageRequest -> AiGameMessageSendRequest 변환
-        org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest aiRequest = 
-            new org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest();
-        
+        AiGameMessageSendRequest aiRequest = new AiGameMessageSendRequest();
         aiRequest.setAiGameRoomId(request.getAiGameRoomId() != null ? request.getAiGameRoomId() : request.getRoomId());
         aiRequest.setSenderId(request.getSenderId());
         aiRequest.setContent(request.getContent());
@@ -174,13 +174,11 @@ public class AiGameRoomServiceAdapter implements RoomService {
     public void sendSystemMessage(String roomId, String message) {
         log.debug("AI 게임룸 시스템 메시지 전송 (어댑터): roomId={}", roomId);
         
-        org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest systemRequest = 
-            new org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest();
-        
+        AiGameMessageSendRequest systemRequest = new AiGameMessageSendRequest();
         systemRequest.setAiGameRoomId(roomId);
         systemRequest.setSenderId("SYSTEM");
         systemRequest.setContent(message);
-        systemRequest.setMessageType(org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM);
+        systemRequest.setMessageType(AiMessageType.SYSTEM);
         systemRequest.setSenderNickname("SYSTEM");
         
         try {
@@ -206,7 +204,7 @@ public class AiGameRoomServiceAdapter implements RoomService {
     public boolean isRoomActive(String roomId) {
         try {
             AiGameRoomResponse room = aiGameRoomService.getAiGameRoom(roomId);
-            return room.getStatus() == org.com.dungeontalk.domain.aichat.common.AiGameStatus.ACTIVE;
+            return room.getStatus() == AiGameStatus.ACTIVE;
         } catch (Exception e) {
             return false;
         }
@@ -246,23 +244,23 @@ public class AiGameRoomServiceAdapter implements RoomService {
     /**
      * 통합 메시지 타입을 AI 메시지 타입으로 매핑
      */
-    private org.com.dungeontalk.domain.aichat.common.AiMessageType mapToAiMessageType(
+    private AiMessageType mapToAiMessageType(
             org.com.dungeontalk.domain.room.common.UnifiedMessageType unifiedType) {
         
         switch (unifiedType) {
             case USER:
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER;
+                return AiMessageType.USER;
             case SYSTEM:
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM;
+                return AiMessageType.SYSTEM;
             case AI_RESPONSE:
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.AI;
+                return AiMessageType.AI;
             case GAME_ACTION:
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER; // GAME_ACTION이 없으므로 USER로 대체
+                return AiMessageType.USER; // GAME_ACTION이 없으므로 USER로 대체
             case GAME_STATE:
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM;
+                return AiMessageType.SYSTEM;
             default:
                 log.warn("지원하지 않는 메시지 타입: {}. USER 타입으로 대체", unifiedType);
-                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER;
+                return AiMessageType.USER;
         }
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomServiceAdapter.java
@@ -1,0 +1,268 @@
+package org.com.dungeontalk.domain.aichat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomCreateRequest;
+import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
+import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
+import org.com.dungeontalk.domain.room.service.RoomService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * AI 게임룸 서비스 어댑터
+ * 기존 AiGameRoomService를 RoomService 인터페이스에 맞게 래핑
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiGameRoomServiceAdapter implements RoomService {
+
+    private final AiGameRoomService aiGameRoomService;
+    private final AiGameMessageService aiGameMessageService;
+
+    @Override
+    public RoomType getSupportedRoomType() {
+        return RoomType.AI_GAME;
+    }
+
+    @Override
+    public UnifiedRoomResponse createRoom(UnifiedRoomRequest request) {
+        log.info("AI 게임룸 생성 요청 (어댑터): roomName={}, creatorId={}", 
+                request.getRoomName(), request.getCreatorId());
+        
+        // 요청 유효성 검증
+        if (!request.isAiGameRoom()) {
+            throw new IllegalArgumentException("AI 게임룸이 아닌 요청입니다: " + request.getRoomType());
+        }
+        
+        // UnifiedRoomRequest -> AiGameRoomCreateRequest 변환
+        AiGameRoomCreateRequest aiRequest = new AiGameRoomCreateRequest();
+        aiRequest.setGameId(request.getGameId());
+        aiRequest.setRoomName(request.getRoomName());
+        aiRequest.setDescription(request.getDescription());
+        aiRequest.setMaxParticipants(request.getMaxParticipants() != null ? request.getMaxParticipants() : 3);
+        aiRequest.setGameSettings(request.getGameSettings());
+        aiRequest.setCreatorId(request.getCreatorId());
+        
+        // 기존 서비스 호출
+        AiGameRoomResponse aiResponse = aiGameRoomService.createAiGameRoom(aiRequest);
+        
+        // 참여자들 추가 (생성자 외 추가 참여자가 있는 경우)
+        if (request.getParticipantIds() != null && request.getParticipantIds().size() > 1) {
+            for (String participantId : request.getParticipantIds()) {
+                if (!participantId.equals(request.getCreatorId())) {
+                    try {
+                        org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest joinReq = 
+                            new org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest();
+                        joinReq.setAiGameRoomId(aiResponse.getId());
+                        joinReq.setParticipantId(participantId);
+                        joinReq.setParticipantNickname(participantId); // 기본값으로 ID 사용
+                        aiGameRoomService.joinAiGameRoom(joinReq);
+                    } catch (Exception e) {
+                        log.warn("참여자 추가 실패: participantId={}, error={}", participantId, e.getMessage());
+                    }
+                }
+            }
+        }
+        
+        // AiGameRoomResponse -> UnifiedRoomResponse 변환
+        UnifiedRoomResponse response = UnifiedRoomResponse.fromAiGameRoom(aiResponse);
+        
+        log.info("AI 게임룸 생성 완료 (어댑터): roomId={}", response.getRoomId());
+        return response;
+    }
+
+    @Override
+    public UnifiedRoomResponse getRoom(String roomId) {
+        log.debug("AI 게임룸 조회 (어댑터): roomId={}", roomId);
+        
+        AiGameRoomResponse aiResponse = aiGameRoomService.getAiGameRoom(roomId);
+        return UnifiedRoomResponse.fromAiGameRoom(aiResponse);
+    }
+
+    @Override
+    public void deleteRoom(String roomId) {
+        log.info("AI 게임룸 삭제 (어댑터): roomId={}", roomId);
+        
+        // AI 게임룸은 일반적으로 직접 삭제하지 않고 상태를 변경
+        // 필요시 aiGameRoomService에 삭제 메서드 추가 후 호출
+        throw new UnsupportedOperationException("AI 게임룸 삭제는 현재 지원되지 않습니다");
+    }
+
+    @Override
+    public List<UnifiedRoomResponse> getAvailableRooms() {
+        log.debug("입장 가능한 AI 게임룸 목록 조회 (어댑터)");
+        
+        List<AiGameRoomResponse> aiRooms = aiGameRoomService.getAvailableRooms();
+        return aiRooms.stream()
+                .map(UnifiedRoomResponse::fromAiGameRoom)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public UnifiedRoomResponse joinRoom(String roomId, String memberId) {
+        log.info("AI 게임룸 참여 (어댑터): roomId={}, memberId={}", roomId, memberId);
+        
+        org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest joinRequest = 
+            new org.com.dungeontalk.domain.aichat.dto.request.AiGameRoomJoinRequest();
+        joinRequest.setAiGameRoomId(roomId);
+        joinRequest.setParticipantId(memberId);
+        joinRequest.setParticipantNickname(memberId); // 기본값으로 ID 사용
+        
+        AiGameRoomResponse aiResponse = aiGameRoomService.joinAiGameRoom(joinRequest);
+        return UnifiedRoomResponse.fromAiGameRoom(aiResponse);
+    }
+
+    @Override
+    public UnifiedRoomResponse leaveRoom(String roomId, String memberId) {
+        log.info("AI 게임룸 퇴장 (어댑터): roomId={}, memberId={}", roomId, memberId);
+        
+        aiGameRoomService.leaveAiGameRoom(roomId, memberId);
+        
+        // 퇴장 후 룸 상태 조회하여 반환
+        AiGameRoomResponse aiResponse = aiGameRoomService.getAiGameRoom(roomId);
+        return UnifiedRoomResponse.fromAiGameRoom(aiResponse);
+    }
+
+    @Override
+    public List<UnifiedRoomResponse> getUserRooms(String memberId) {
+        log.debug("사용자 참여 AI 게임룸 목록 조회 (어댑터): memberId={}", memberId);
+        
+        List<AiGameRoomResponse> userRooms = aiGameRoomService.getUserParticipatingRooms(memberId);
+        return userRooms.stream()
+                .map(UnifiedRoomResponse::fromAiGameRoom)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void processMessage(UnifiedMessageRequest request) {
+        log.debug("AI 게임 메시지 처리 (어댑터): roomId={}, messageType={}", 
+                request.getRoomId(), request.getMessageType());
+        
+        // 요청 유효성 검증
+        if (!request.isAiGameMessage()) {
+            throw new IllegalArgumentException("AI 게임 메시지가 아닙니다: " + request.getRoomType());
+        }
+        
+        // UnifiedMessageRequest -> AiGameMessageSendRequest 변환
+        org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest aiRequest = 
+            new org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest();
+        
+        aiRequest.setAiGameRoomId(request.getAiGameRoomId() != null ? request.getAiGameRoomId() : request.getRoomId());
+        aiRequest.setSenderId(request.getSenderId());
+        aiRequest.setContent(request.getContent());
+        aiRequest.setMessageType(mapToAiMessageType(request.getMessageType()));
+        aiRequest.setSenderNickname(request.getSenderId()); // 기본값으로 ID 사용
+        
+        // 기존 AI 메시지 서비스 호출
+        try {
+            aiGameMessageService.processMessage(aiRequest);
+        } catch (Exception e) {
+            log.error("AI 게임 메시지 처리 중 오류 발생: roomId={}, error={}", 
+                    request.getRoomId(), e.getMessage(), e);
+            throw new RuntimeException("AI 게임 메시지 처리 실패", e);
+        }
+    }
+
+    @Override
+    public void sendSystemMessage(String roomId, String message) {
+        log.debug("AI 게임룸 시스템 메시지 전송 (어댑터): roomId={}", roomId);
+        
+        org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest systemRequest = 
+            new org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest();
+        
+        systemRequest.setAiGameRoomId(roomId);
+        systemRequest.setSenderId("SYSTEM");
+        systemRequest.setContent(message);
+        systemRequest.setMessageType(org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM);
+        systemRequest.setSenderNickname("SYSTEM");
+        
+        try {
+            aiGameMessageService.processMessage(systemRequest);
+        } catch (Exception e) {
+            log.error("AI 게임 시스템 메시지 전송 중 오류 발생: roomId={}, error={}", 
+                    roomId, e.getMessage(), e);
+            throw new RuntimeException("AI 게임 시스템 메시지 전송 실패", e);
+        }
+    }
+
+    @Override
+    public boolean existsRoom(String roomId) {
+        try {
+            aiGameRoomService.getAiGameRoom(roomId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isRoomActive(String roomId) {
+        try {
+            AiGameRoomResponse room = aiGameRoomService.getAiGameRoom(roomId);
+            return room.getStatus() == org.com.dungeontalk.domain.aichat.common.AiGameStatus.ACTIVE;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canJoinRoom(String roomId, String memberId) {
+        try {
+            AiGameRoomResponse room = aiGameRoomService.getAiGameRoom(roomId);
+            return room.getCurrentParticipantCount() < room.getMaxParticipants() &&
+                   !room.getParticipants().contains(memberId);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int getCurrentParticipantCount(String roomId) {
+        try {
+            AiGameRoomResponse room = aiGameRoomService.getAiGameRoom(roomId);
+            return room.getCurrentParticipantCount();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public int getMaxParticipantCount(String roomId) {
+        try {
+            AiGameRoomResponse room = aiGameRoomService.getAiGameRoom(roomId);
+            return room.getMaxParticipants();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * 통합 메시지 타입을 AI 메시지 타입으로 매핑
+     */
+    private org.com.dungeontalk.domain.aichat.common.AiMessageType mapToAiMessageType(
+            org.com.dungeontalk.domain.room.common.UnifiedMessageType unifiedType) {
+        
+        switch (unifiedType) {
+            case USER:
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER;
+            case SYSTEM:
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM;
+            case AI_RESPONSE:
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.AI;
+            case GAME_ACTION:
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER; // GAME_ACTION이 없으므로 USER로 대체
+            case GAME_STATE:
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.SYSTEM;
+            default:
+                log.warn("지원하지 않는 메시지 타입: {}. USER 타입으로 대체", unifiedType);
+                return org.com.dungeontalk.domain.aichat.common.AiMessageType.USER;
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/request/ChatMessageSendRequestDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/request/ChatMessageSendRequestDto.java
@@ -1,11 +1,17 @@
 package org.com.dungeontalk.domain.chat.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.com.dungeontalk.domain.chat.common.MessageType;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class ChatMessageSendRequestDto {
     private String messageId;
     private String roomId;              // 클라이언트에서 보내야 함

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomServiceAdapter.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomServiceAdapter.java
@@ -8,6 +8,7 @@ import org.com.dungeontalk.domain.chat.dto.request.ChatMessageSendRequestDto;
 import org.com.dungeontalk.domain.chat.common.ChatMode;
 import org.com.dungeontalk.domain.chat.common.MessageType;
 import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.common.UnifiedMessageType;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
 import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
 import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
@@ -150,13 +151,14 @@ public class ChatRoomServiceAdapter implements RoomService {
             throw new IllegalArgumentException("플레이어 채팅 메시지가 아닙니다: " + request.getRoomType());
         }
         
-        // UnifiedMessageRequest -> ChatMessageSendRequestDto 변환
-        ChatMessageSendRequestDto chatRequest = new ChatMessageSendRequestDto();
-        chatRequest.setRoomId(request.getChatRoomId() != null ? request.getChatRoomId() : request.getRoomId());
-        chatRequest.setSenderId(request.getSenderId());
-        chatRequest.setContent(request.getContent());
-        chatRequest.setType(mapToChatMessageType(request.getMessageType()));
-        chatRequest.setSenderNickname(request.getSenderNickname() != null ? request.getSenderNickname() : request.getSenderId());
+        // UnifiedMessageRequest -> ChatMessageSendRequestDto 변환 (빌더 패턴 사용)
+        ChatMessageSendRequestDto chatRequest = ChatMessageSendRequestDto.builder()
+                .roomId(request.getChatRoomId() != null ? request.getChatRoomId() : request.getRoomId())
+                .senderId(request.getSenderId())
+                .content(request.getContent())
+                .type(mapToChatMessageType(request.getMessageType()))
+                .senderNickname(request.getSenderNickname() != null ? request.getSenderNickname() : request.getSenderId())
+                .build();
         
         // 닉네임 설정 (있는 경우)
         if (request.getSenderNickname() != null) {
@@ -178,12 +180,13 @@ public class ChatRoomServiceAdapter implements RoomService {
     public void sendSystemMessage(String roomId, String message) {
         log.debug("플레이어 채팅룸 시스템 메시지 전송 (어댑터): roomId={}", roomId);
         
-        ChatMessageSendRequestDto systemRequest = new ChatMessageSendRequestDto();
-        systemRequest.setRoomId(roomId);
-        systemRequest.setSenderId("SYSTEM");
-        systemRequest.setContent(message);
-        systemRequest.setType(MessageType.TALK); // SYSTEM이 없으므로 TALK으로 대체
-        systemRequest.setSenderNickname("SYSTEM");
+        ChatMessageSendRequestDto systemRequest = ChatMessageSendRequestDto.builder()
+                .roomId(roomId)
+                .senderId("SYSTEM")
+                .content(message)
+                .type(MessageType.TALK) // SYSTEM이 없으므로 TALK으로 대체
+                .senderNickname("SYSTEM")
+                .build();
         
         try {
             chatMessageService.processMessage(systemRequest);
@@ -251,7 +254,7 @@ public class ChatRoomServiceAdapter implements RoomService {
     /**
      * 통합 메시지 타입을 채팅 메시지 타입으로 매핑
      */
-    private MessageType mapToChatMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType unifiedType) {
+    private MessageType mapToChatMessageType(UnifiedMessageType unifiedType) {
         switch (unifiedType) {
             case USER:
                 return MessageType.TALK;

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomServiceAdapter.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatRoomServiceAdapter.java
@@ -1,0 +1,271 @@
+package org.com.dungeontalk.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.chat.dto.ChatRoomDto;
+import org.com.dungeontalk.domain.chat.dto.request.ChatRoomCreateRequestDto;
+import org.com.dungeontalk.domain.chat.dto.request.ChatMessageSendRequestDto;
+import org.com.dungeontalk.domain.chat.common.ChatMode;
+import org.com.dungeontalk.domain.chat.common.MessageType;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
+import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
+import org.com.dungeontalk.domain.room.service.RoomService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 채팅룸 서비스 어댑터
+ * 기존 ChatRoomService를 RoomService 인터페이스에 맞게 래핑
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceAdapter implements RoomService {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    @Override
+    public RoomType getSupportedRoomType() {
+        return RoomType.PLAYER_CHAT;
+    }
+
+    @Override
+    public UnifiedRoomResponse createRoom(UnifiedRoomRequest request) {
+        log.info("플레이어 채팅룸 생성 요청 (어댑터): roomName={}, creatorId={}", 
+                request.getRoomName(), request.getCreatorId());
+        
+        // 요청 유효성 검증
+        if (!request.isPlayerChatRoom()) {
+            throw new IllegalArgumentException("플레이어 채팅룸이 아닌 요청입니다: " + request.getRoomType());
+        }
+        
+        // UnifiedRoomRequest -> ChatRoomCreateRequestDto 변환
+        ChatRoomCreateRequestDto chatRequest = new ChatRoomCreateRequestDto();
+        chatRequest.setRoomName(request.getRoomName());
+        chatRequest.setMode(request.getChatMode() != null ? request.getChatMode() : ChatMode.MULTI);
+        chatRequest.setMaxCapacity(request.getMaxCapacity());
+        
+        // 기존 서비스 호출
+        ChatRoomDto chatResponse = chatRoomService.createRoom(chatRequest);
+        
+        // 참여자들 추가
+        if (request.getParticipantIds() != null && !request.getParticipantIds().isEmpty()) {
+            for (String participantId : request.getParticipantIds()) {
+                try {
+                    chatRoomService.joinRoom(chatResponse.getId(), participantId);
+                } catch (Exception e) {
+                    log.warn("참여자 추가 실패: participantId={}, error={}", participantId, e.getMessage());
+                }
+            }
+        }
+        
+        // ChatRoomDto -> UnifiedRoomResponse 변환
+        UnifiedRoomResponse response = UnifiedRoomResponse.fromPlayerChatRoom(chatResponse);
+        
+        log.info("플레이어 채팅룸 생성 완료 (어댑터): roomId={}", response.getRoomId());
+        return response;
+    }
+
+    @Override
+    public UnifiedRoomResponse getRoom(String roomId) {
+        log.debug("플레이어 채팅룸 조회 (어댑터): roomId={}", roomId);
+        
+        ChatRoomDto chatResponse = chatRoomService.getRoomById(roomId);
+        return UnifiedRoomResponse.fromPlayerChatRoom(chatResponse);
+    }
+
+    @Override
+    public void deleteRoom(String roomId) {
+        log.info("플레이어 채팅룸 삭제 (어댑터): roomId={}", roomId);
+        
+        // 채팅룸은 일반적으로 직접 삭제하지 않음
+        // 필요시 chatRoomService에 삭제 메서드 추가 후 호출
+        throw new UnsupportedOperationException("플레이어 채팅룸 삭제는 현재 지원되지 않습니다");
+    }
+
+    @Override
+    public List<UnifiedRoomResponse> getAvailableRooms() {
+        log.debug("입장 가능한 플레이어 채팅룸 목록 조회 (어댑터)");
+        
+        List<ChatRoomDto> chatRooms = chatRoomService.getAllRooms();
+        return chatRooms.stream()
+                .map(UnifiedRoomResponse::fromPlayerChatRoom)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public UnifiedRoomResponse joinRoom(String roomId, String memberId) {
+        log.info("플레이어 채팅룸 참여 (어댑터): roomId={}, memberId={}", roomId, memberId);
+        
+        boolean joined = chatRoomService.joinRoom(roomId, memberId);
+        if (!joined) {
+            throw new RuntimeException("채팅룸 참여에 실패했습니다. 정원이 초과되었거나 이미 참여중일 수 있습니다.");
+        }
+        
+        // 참여 후 룸 상태 조회하여 반환
+        ChatRoomDto chatResponse = chatRoomService.getRoomById(roomId);
+        return UnifiedRoomResponse.fromPlayerChatRoom(chatResponse);
+    }
+
+    @Override
+    public UnifiedRoomResponse leaveRoom(String roomId, String memberId) {
+        log.info("플레이어 채팅룸 퇴장 (어댑터): roomId={}, memberId={}", roomId, memberId);
+        
+        boolean left = chatRoomService.leaveRoom(roomId, memberId);
+        if (!left) {
+            log.warn("채팅룸 퇴장 실패 또는 이미 퇴장된 상태: roomId={}, memberId={}", roomId, memberId);
+        }
+        
+        // 퇴장 후 룸 상태 조회하여 반환
+        ChatRoomDto chatResponse = chatRoomService.getRoomById(roomId);
+        return UnifiedRoomResponse.fromPlayerChatRoom(chatResponse);
+    }
+
+    @Override
+    public List<UnifiedRoomResponse> getUserRooms(String memberId) {
+        log.debug("사용자 참여 플레이어 채팅룸 목록 조회 (어댑터): memberId={}", memberId);
+        
+        // 현재 ChatRoomService에 사용자별 룸 조회 메서드가 없으므로 전체 룸에서 필터링
+        // 실제로는 Redis나 DB에서 사용자가 참여중인 룸만 조회하는 것이 효율적
+        List<ChatRoomDto> allRooms = chatRoomService.getAllRooms();
+        
+        // TODO: 실제 구현에서는 사용자가 참여중인 룸만 필터링하는 로직 추가 필요
+        return allRooms.stream()
+                .map(UnifiedRoomResponse::fromPlayerChatRoom)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void processMessage(UnifiedMessageRequest request) {
+        log.debug("플레이어 채팅 메시지 처리 (어댑터): roomId={}, messageType={}", 
+                request.getRoomId(), request.getMessageType());
+        
+        // 요청 유효성 검증
+        if (!request.isPlayerChatMessage()) {
+            throw new IllegalArgumentException("플레이어 채팅 메시지가 아닙니다: " + request.getRoomType());
+        }
+        
+        // UnifiedMessageRequest -> ChatMessageSendRequestDto 변환
+        ChatMessageSendRequestDto chatRequest = new ChatMessageSendRequestDto();
+        chatRequest.setRoomId(request.getChatRoomId() != null ? request.getChatRoomId() : request.getRoomId());
+        chatRequest.setSenderId(request.getSenderId());
+        chatRequest.setContent(request.getContent());
+        chatRequest.setType(mapToChatMessageType(request.getMessageType()));
+        chatRequest.setSenderNickname(request.getSenderNickname() != null ? request.getSenderNickname() : request.getSenderId());
+        
+        // 닉네임 설정 (있는 경우)
+        if (request.getSenderNickname() != null) {
+            // ChatMessageSendRequestDto에 nickname 필드가 있다면 설정
+            // 현재 구조상 nickname은 별도 처리가 필요할 수 있음
+        }
+        
+        // 기존 채팅 메시지 서비스 호출
+        try {
+            chatMessageService.processMessage(chatRequest);
+        } catch (Exception e) {
+            log.error("플레이어 채팅 메시지 처리 중 오류 발생: roomId={}, error={}", 
+                    request.getRoomId(), e.getMessage(), e);
+            throw new RuntimeException("플레이어 채팅 메시지 처리 실패", e);
+        }
+    }
+
+    @Override
+    public void sendSystemMessage(String roomId, String message) {
+        log.debug("플레이어 채팅룸 시스템 메시지 전송 (어댑터): roomId={}", roomId);
+        
+        ChatMessageSendRequestDto systemRequest = new ChatMessageSendRequestDto();
+        systemRequest.setRoomId(roomId);
+        systemRequest.setSenderId("SYSTEM");
+        systemRequest.setContent(message);
+        systemRequest.setType(MessageType.TALK); // SYSTEM이 없으므로 TALK으로 대체
+        systemRequest.setSenderNickname("SYSTEM");
+        
+        try {
+            chatMessageService.processMessage(systemRequest);
+        } catch (Exception e) {
+            log.error("플레이어 채팅 시스템 메시지 전송 중 오류 발생: roomId={}, error={}", 
+                    roomId, e.getMessage(), e);
+            throw new RuntimeException("플레이어 채팅 시스템 메시지 전송 실패", e);
+        }
+    }
+
+    @Override
+    public boolean existsRoom(String roomId) {
+        try {
+            chatRoomService.getRoomById(roomId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isRoomActive(String roomId) {
+        try {
+            ChatRoomDto room = chatRoomService.getRoomById(roomId);
+            // 채팅룸은 생성되면 활성 상태로 간주
+            return room != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canJoinRoom(String roomId, String memberId) {
+        try {
+            ChatRoomDto room = chatRoomService.getRoomById(roomId);
+            // 정원 체크는 chatRoomService.joinRoom()에서 처리되므로 여기서는 룸 존재 여부만 확인
+            return room != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public int getCurrentParticipantCount(String roomId) {
+        try {
+            // 현재 ChatRoomDto에 참여자 수 정보가 없으므로 0 반환
+            // 실제로는 Redis에서 현재 온라인 사용자 수를 조회해야 함
+            return 0;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    @Override
+    public int getMaxParticipantCount(String roomId) {
+        try {
+            ChatRoomDto room = chatRoomService.getRoomById(roomId);
+            // ChatRoomDto에 getMaxCapacity() 메서드가 없으므로 기본값 반환
+            return Integer.MAX_VALUE;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * 통합 메시지 타입을 채팅 메시지 타입으로 매핑
+     */
+    private MessageType mapToChatMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType unifiedType) {
+        switch (unifiedType) {
+            case USER:
+                return MessageType.TALK;
+            case SYSTEM:
+                return MessageType.TALK; // SYSTEM이 없으므로 TALK으로 대체
+            case OTHER_PLAYER:
+                return MessageType.TALK;
+            case PRESENCE:
+                return MessageType.PRESENCE;
+            case ROOM_INFO:
+                return MessageType.TALK;
+            default:
+                log.warn("지원하지 않는 메시지 타입: {}. TALK 타입으로 대체", unifiedType);
+                return MessageType.TALK;
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/matching/service/MatchingService.java
+++ b/src/main/java/org/com/dungeontalk/domain/matching/service/MatchingService.java
@@ -10,6 +10,10 @@ import org.com.dungeontalk.domain.chat.common.ChatRoomType;
 import org.com.dungeontalk.domain.chat.dto.ChatRoomDto;
 import org.com.dungeontalk.domain.chat.dto.request.ChatRoomCreateRequestDto;
 import org.com.dungeontalk.domain.chat.service.ChatRoomService;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
+import org.com.dungeontalk.domain.room.service.RoomServiceFactory;
 import org.com.dungeontalk.domain.matching.common.MatchingConstants;
 import org.com.dungeontalk.domain.matching.common.MatchingStatus;
 import org.com.dungeontalk.domain.matching.common.WorldType;
@@ -43,6 +47,7 @@ public class MatchingService {
     private final ChatRoomService chatRoomService;
     private final StringRedisTemplate redisTemplate;
     private final MatchingWebSocketService webSocketService;
+    private final RoomServiceFactory roomServiceFactory;
 
     /**
      * WebSocket 매칭 참가 처리 (컨트롤러 단순화용)
@@ -257,24 +262,23 @@ public class MatchingService {
             // 2. 게임 세션 ID 생성
             String gameSessionId = UuidV7Creator.create();
 
-            // 3. AI 게임방 생성
-            AiGameRoomResponse aiGameRoom = createAiGameRoom(gameSessionId, participants, worldType);
+            // 3. 통합 룸 생성 (신규 방식)
+            Map<String, String> roomIds = createUnifiedRooms(gameSessionId, participants, worldType);
+            String aiGameRoomId = roomIds.get("ai");
+            String chatRoomId = roomIds.get("chat");
 
-            // 4. 일반 채팅방 생성
-            ChatRoomDto chatRoom = createChatRoom(gameSessionId, participants, worldType);
+            // 4. 매칭 세션 정보 Redis에 저장
+            saveMatchingSession(gameSessionId, aiGameRoomId, chatRoomId, participants, worldType);
 
-            // 5. 매칭 세션 정보 Redis에 저장
-            saveMatchingSession(gameSessionId, aiGameRoom.getId(), chatRoom.getId(), participants, worldType);
-
-            // 6. WebSocket으로 매칭 완료 알림 전송
+            // 5. WebSocket으로 매칭 완료 알림 전송
             webSocketService.sendMatchingComplete(participants, worldType, gameSessionId, 
-                                                 aiGameRoom.getId(), chatRoom.getId());
+                                                 aiGameRoomId, chatRoomId);
 
-            // 7. 매칭 완료된 사용자들 상태 정리
+            // 6. 매칭 완료된 사용자들 상태 정리
             queueManager.cleanupMatchedUsers(participants);
 
             MatchingCompleteResponse response = MatchingCompleteResponse.of(
-                    gameSessionId, aiGameRoom.getId(), chatRoom.getId(), worldType, participants
+                    gameSessionId, aiGameRoomId, chatRoomId, worldType, participants
             );
 
             log.info("매칭 처리 완료: gameSessionId={}, participants={}", gameSessionId, participants);
@@ -296,7 +300,9 @@ public class MatchingService {
 
     /**
      * AI 게임방 생성
+     * @deprecated 통합 룸 생성 메서드 createUnifiedRooms() 사용 권장
      */
+    @Deprecated
     private AiGameRoomResponse createAiGameRoom(String gameSessionId, List<String> participants, WorldType worldType) {
         AiGameRoomCreateRequest request = new AiGameRoomCreateRequest();
         request.setGameId(gameSessionId);
@@ -318,7 +324,9 @@ public class MatchingService {
 
     /**
      * 일반 채팅방 생성
+     * @deprecated 통합 룸 생성 메서드 createUnifiedRooms() 사용 권장
      */
+    @Deprecated
     private ChatRoomDto createChatRoom(String gameSessionId, List<String> participants, WorldType worldType) {
         ChatRoomCreateRequestDto request = new ChatRoomCreateRequestDto();
         request.setRoomName(new StringBuilder()
@@ -394,6 +402,123 @@ public class MatchingService {
                 }
             } catch (Exception e) {
                 log.error("정기 매칭 처리 중 오류: worldType={}", worldType, e);
+            }
+        }
+    }
+
+    // === 통합 룸 생성 메서드 (신규) ===
+
+    /**
+     * 통합된 룸 생성 메서드 (신규 - 중복 제거용)
+     * AI 게임룸과 채팅룸을 한 번에 생성하고 ID 맵을 반환
+     */
+    public Map<String, String> createUnifiedRooms(String gameSessionId, List<String> participants, WorldType worldType) {
+        log.info("통합 룸 생성 시작: gameSessionId={}, participants={}, worldType={}", gameSessionId, participants, worldType);
+        
+        Map<String, String> roomIds = new HashMap<>();
+        
+        try {
+            // 1. AI 게임룸 생성 (통합 API 사용)
+            UnifiedRoomRequest aiRoomRequest = UnifiedRoomRequest.builder()
+                    .roomType(RoomType.AI_GAME)
+                    .roomName(worldType.getDisplayName() + " 랜덤 매칭")
+                    .description("랜덤 매칭으로 생성된 " + worldType.getDisplayName() + " 게임방")
+                    .maxParticipants(3)
+                    .creatorId(participants.get(0))
+                    .participantIds(participants)
+                    .gameId(gameSessionId)
+                    .gameSettings(worldType.getGameSettings())
+                    .build();
+            
+            UnifiedRoomResponse aiRoom = roomServiceFactory.getService(RoomType.AI_GAME).createRoom(aiRoomRequest);
+            roomIds.put("ai", aiRoom.getRoomId());
+            
+            // 2. 플레이어 채팅룸 생성 (통합 API 사용)
+            UnifiedRoomRequest chatRoomRequest = UnifiedRoomRequest.builder()
+                    .roomType(RoomType.PLAYER_CHAT)
+                    .roomName(worldType.getDisplayName() + " 채팅방")
+                    .maxParticipants(3)
+                    .creatorId(participants.get(0))
+                    .participantIds(participants)
+                    .chatMode(ChatMode.MULTI)
+                    .build();
+            
+            UnifiedRoomResponse chatRoom = roomServiceFactory.getService(RoomType.PLAYER_CHAT).createRoom(chatRoomRequest);
+            roomIds.put("chat", chatRoom.getRoomId());
+            
+            log.info("통합 룸 생성 완료: aiRoomId={}, chatRoomId={}", roomIds.get("ai"), roomIds.get("chat"));
+            
+            return roomIds;
+            
+        } catch (Exception e) {
+            log.error("통합 룸 생성 중 오류 발생: gameSessionId={}", gameSessionId, e);
+            throw new MatchingException(ErrorCode.MATCHING_PROCESSING_ERROR, "룸 생성 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 기존 매칭 처리 로직에서 통합 룸 생성 사용 (기존 메서드 대체용)
+     */
+    public MatchingCompleteResponse processMatchingWithUnifiedRooms(WorldType worldType) {
+        log.info("통합 룸 기반 매칭 처리 시작: worldType={}", worldType);
+        
+        String lockKey = MatchingConstants.LOCK_KEY_PREFIX + worldType.name();
+        Boolean lockAcquired = false;
+        
+        try {
+            // 분산 락 획득 (5초 타임아웃)
+            lockAcquired = redisTemplate.opsForValue().setIfAbsent(lockKey, "PROCESSING", Duration.ofSeconds(5));
+            
+            if (!Boolean.TRUE.equals(lockAcquired)) {
+                log.warn("매칭 처리 락 획득 실패: worldType={} - 다른 프로세스에서 처리 중", worldType);
+                return null;
+            }
+            
+            log.debug("매칭 처리 락 획득 성공: worldType={}", worldType);
+
+        try {
+            // 1. 큐에서 3명 추출
+            List<String> participants = queueManager.extractThreeUsers(worldType);
+            if (participants.size() != 3) {
+                log.warn("매칭 대상 부족: worldType={}, participants={}", worldType, participants.size());
+                return null;
+            }
+
+            // 2. 게임 세션 ID 생성
+            String gameSessionId = UuidV7Creator.create();
+
+            // 3. 통합 룸 생성 (신규 메서드 사용)
+            Map<String, String> roomIds = createUnifiedRooms(gameSessionId, participants, worldType);
+            String aiGameRoomId = roomIds.get("ai");
+            String chatRoomId = roomIds.get("chat");
+
+            // 4. 매칭 세션 정보 Redis에 저장
+            saveMatchingSession(gameSessionId, aiGameRoomId, chatRoomId, participants, worldType);
+
+            // 5. WebSocket으로 매칭 완료 알림 전송
+            webSocketService.sendMatchingComplete(participants, worldType, gameSessionId, 
+                                                 aiGameRoomId, chatRoomId);
+
+            // 6. 매칭 완료된 사용자들 상태 정리
+            queueManager.cleanupMatchedUsers(participants);
+
+            MatchingCompleteResponse response = MatchingCompleteResponse.of(
+                    gameSessionId, aiGameRoomId, chatRoomId, worldType, participants
+            );
+
+            log.info("통합 룸 기반 매칭 처리 완료: gameSessionId={}, participants={}", gameSessionId, participants);
+            return response;
+
+        } catch (Exception e) {
+            log.error("통합 룸 기반 매칭 처리 중 오류 발생: worldType={}", worldType, e);
+            throw new MatchingException(ErrorCode.MATCHING_PROCESSING_ERROR, e.getMessage());
+        }
+        
+        } finally {
+            // 분산 락 해제
+            if (Boolean.TRUE.equals(lockAcquired)) {
+                redisTemplate.delete(lockKey);
+                log.debug("매칭 처리 락 해제 완료: worldType={}", worldType);
             }
         }
     }

--- a/src/main/java/org/com/dungeontalk/domain/room/common/RoomType.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/common/RoomType.java
@@ -1,0 +1,51 @@
+package org.com.dungeontalk.domain.room.common;
+
+/**
+ * 룸 타입을 정의하는 열거형
+ * AI 게임룸과 플레이어 채팅룸을 구분
+ */
+public enum RoomType {
+    /**
+     * AI와 상호작용하는 게임룸
+     * - 턴제 게임
+     * - AI 응답 대기
+     * - 게임 상태 관리
+     */
+    AI_GAME("ai", "AI 게임룸"),
+    
+    /**
+     * 플레이어간 일반 채팅룸
+     * - 실시간 채팅
+     * - 다중 사용자
+     * - 단순 메시지 교환
+     */
+    PLAYER_CHAT("chat", "플레이어 채팅룸");
+
+    private final String code;
+    private final String displayName;
+
+    RoomType(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * 코드로 RoomType 찾기
+     */
+    public static RoomType fromCode(String code) {
+        for (RoomType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown room type code: " + code);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/common/UnifiedMessageType.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/common/UnifiedMessageType.java
@@ -1,0 +1,99 @@
+package org.com.dungeontalk.domain.room.common;
+
+/**
+ * 통합된 메시지 타입
+ * AI 채팅과 일반 채팅의 메시지 타입을 통합
+ */
+public enum UnifiedMessageType {
+    // === 공통 메시지 타입 ===
+    /**
+     * 사용자가 보낸 일반 메시지
+     */
+    USER("user", "사용자 메시지"),
+    
+    /**
+     * 시스템이 생성한 메시지 (입장/퇴장 등)
+     */
+    SYSTEM("system", "시스템 메시지"),
+    
+    // === AI 게임 전용 메시지 타입 ===
+    /**
+     * AI가 생성한 응답 메시지
+     */
+    AI_RESPONSE("ai", "AI 응답"),
+    
+    /**
+     * 게임 상태 변경 메시지 (턴 시작/종료 등)
+     */
+    GAME_STATE("game_state", "게임 상태"),
+    
+    /**
+     * 게임 액션 메시지 (플레이어 행동)
+     */
+    GAME_ACTION("game_action", "게임 액션"),
+    
+    // === 플레이어 채팅 전용 메시지 타입 ===
+    /**
+     * 다른 플레이어가 보낸 메시지
+     */
+    OTHER_PLAYER("other", "다른 플레이어"),
+    
+    /**
+     * 접속자 상태 변경 메시지
+     */
+    PRESENCE("presence", "접속 상태"),
+    
+    /**
+     * 룸 정보 변경 메시지 (정원 변경 등)
+     */
+    ROOM_INFO("room_info", "룸 정보");
+
+    private final String code;
+    private final String displayName;
+
+    UnifiedMessageType(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * AI 게임에서 사용되는 메시지 타입인지 확인
+     */
+    public boolean isAiGameType() {
+        return this == AI_RESPONSE || this == GAME_STATE || this == GAME_ACTION;
+    }
+
+    /**
+     * 플레이어 채팅에서 사용되는 메시지 타입인지 확인
+     */
+    public boolean isPlayerChatType() {
+        return this == OTHER_PLAYER || this == PRESENCE || this == ROOM_INFO;
+    }
+
+    /**
+     * 공통으로 사용되는 메시지 타입인지 확인
+     */
+    public boolean isCommonType() {
+        return this == USER || this == SYSTEM;
+    }
+
+    /**
+     * 코드로 메시지 타입 찾기
+     */
+    public static UnifiedMessageType fromCode(String code) {
+        for (UnifiedMessageType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown message type code: " + code);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/common/UnifiedRoomStatus.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/common/UnifiedRoomStatus.java
@@ -1,0 +1,129 @@
+package org.com.dungeontalk.domain.room.common;
+
+/**
+ * 통합된 룸 상태
+ * AI 게임룸과 플레이어 채팅룸의 상태를 통합
+ */
+public enum UnifiedRoomStatus {
+    // === 공통 상태 ===
+    /**
+     * 룸이 생성됨 (아직 활성화되지 않음)
+     */
+    CREATED("created", "생성됨"),
+    
+    /**
+     * 룸이 활성 상태 (사용 가능)
+     */
+    ACTIVE("active", "활성"),
+    
+    /**
+     * 룸이 일시 정지됨
+     */
+    PAUSED("paused", "일시정지"),
+    
+    /**
+     * 룸이 완료/종료됨
+     */
+    COMPLETED("completed", "완료"),
+    
+    /**
+     * 룸에 오류가 발생함
+     */
+    ERROR("error", "오류"),
+    
+    // === AI 게임 전용 상태 ===
+    /**
+     * AI 응답 처리 중
+     */
+    AI_PROCESSING("ai_processing", "AI 처리중"),
+    
+    /**
+     * 플레이어 턴 대기 중
+     */
+    WAITING_PLAYER_INPUT("waiting_input", "입력대기"),
+    
+    /**
+     * 게임 종료
+     */
+    GAME_ENDED("game_ended", "게임종료"),
+    
+    // === 플레이어 채팅 전용 상태 ===
+    /**
+     * 채팅 가능 상태
+     */
+    CHAT_AVAILABLE("chat_available", "채팅가능"),
+    
+    /**
+     * 정원 초과로 입장 불가
+     */
+    FULL("full", "정원초과"),
+    
+    /**
+     * 비활성 상태 (아무도 접속하지 않음)
+     */
+    INACTIVE("inactive", "비활성");
+
+    private final String code;
+    private final String displayName;
+
+    UnifiedRoomStatus(String code, String displayName) {
+        this.code = code;
+        this.displayName = displayName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * AI 게임에서 사용되는 상태인지 확인
+     */
+    public boolean isAiGameStatus() {
+        return this == AI_PROCESSING || this == WAITING_PLAYER_INPUT || this == GAME_ENDED;
+    }
+
+    /**
+     * 플레이어 채팅에서 사용되는 상태인지 확인
+     */
+    public boolean isPlayerChatStatus() {
+        return this == CHAT_AVAILABLE || this == FULL || this == INACTIVE;
+    }
+
+    /**
+     * 공통으로 사용되는 상태인지 확인
+     */
+    public boolean isCommonStatus() {
+        return this == CREATED || this == ACTIVE || this == PAUSED || 
+               this == COMPLETED || this == ERROR;
+    }
+
+    /**
+     * 룸이 사용 가능한 상태인지 확인
+     */
+    public boolean isUsable() {
+        return this == ACTIVE || this == CHAT_AVAILABLE || this == WAITING_PLAYER_INPUT;
+    }
+
+    /**
+     * 룸이 종료된 상태인지 확인
+     */
+    public boolean isTerminated() {
+        return this == COMPLETED || this == ERROR || this == GAME_ENDED;
+    }
+
+    /**
+     * 코드로 상태 찾기
+     */
+    public static UnifiedRoomStatus fromCode(String code) {
+        for (UnifiedRoomStatus status : values()) {
+            if (status.code.equals(code)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown room status code: " + code);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedRoomController.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedRoomController.java
@@ -1,0 +1,240 @@
+package org.com.dungeontalk.domain.room.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
+import org.com.dungeontalk.domain.room.service.RoomService;
+import org.com.dungeontalk.domain.room.service.RoomServiceFactory;
+import org.com.dungeontalk.global.rsData.RsData;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 통합된 룸 컨트롤러
+ * AI 게임룸과 플레이어 채팅룸을 통합 관리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/rooms")
+@RequiredArgsConstructor
+public class UnifiedRoomController {
+
+    private final RoomServiceFactory roomServiceFactory;
+
+    /**
+     * 새로운 룸을 생성합니다
+     */
+    @PostMapping
+    public RsData<UnifiedRoomResponse> createRoom(@Valid @RequestBody UnifiedRoomRequest request) {
+        log.info("룸 생성 요청: roomType={}, roomName={}, creatorId={}", 
+                request.getRoomType(), request.getRoomName(), request.getCreatorId());
+        
+        try {
+            // 요청 유효성 검증
+            request.validateByRoomType();
+            
+            // 해당 타입의 서비스 가져오기
+            RoomService roomService = roomServiceFactory.getService(request.getRoomType());
+            
+            // 룸 생성
+            UnifiedRoomResponse response = roomService.createRoom(request);
+            
+            log.info("룸 생성 성공: roomId={}, roomType={}", 
+                    response.getRoomId(), response.getRoomType());
+            
+            return RsData.of("200", "룸 생성 성공", response);
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("룸 생성 실패 - 잘못된 요청: {}", e.getMessage());
+            return RsData.of("400", "잘못된 요청: " + e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("룸 생성 중 오류 발생: roomType={}", request.getRoomType(), e);
+            return RsData.of("500", "룸 생성 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 룸 정보를 조회합니다
+     */
+    @GetMapping("/{roomType}/{roomId}")
+    public RsData<UnifiedRoomResponse> getRoom(@PathVariable String roomType, 
+                                             @PathVariable String roomId) {
+        log.debug("룸 조회 요청: roomType={}, roomId={}", roomType, roomId);
+        
+        try {
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            UnifiedRoomResponse response = roomService.getRoom(roomId);
+            
+            return RsData.of("200", "룸 조회 성공", response);
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("룸 조회 실패 - 잘못된 요청: roomType={}, roomId={}, error={}", 
+                    roomType, roomId, e.getMessage());
+            return RsData.of("400", "잘못된 요청: " + e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("룸 조회 중 오류 발생: roomType={}, roomId={}", roomType, roomId, e);
+            return RsData.of("500", "룸 조회 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 입장 가능한 룸 목록을 조회합니다
+     */
+    @GetMapping("/available")
+    public RsData<Map<String, List<UnifiedRoomResponse>>> getAvailableRooms() {
+        log.debug("입장 가능한 룸 목록 조회 요청");
+        
+        try {
+            Map<String, List<UnifiedRoomResponse>> availableRooms = roomServiceFactory
+                    .getSupportedRoomTypes()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            RoomType::getCode,
+                            roomType -> {
+                                try {
+                                    RoomService service = roomServiceFactory.getService(roomType);
+                                    return service.getAvailableRooms();
+                                } catch (Exception e) {
+                                    log.warn("룸 타입 {} 조회 중 오류: {}", roomType, e.getMessage());
+                                    return List.of();
+                                }
+                            }
+                    ));
+            
+            return RsData.of("200", "입장 가능한 룸 목록 조회 성공", availableRooms);
+            
+        } catch (Exception e) {
+            log.error("입장 가능한 룸 목록 조회 중 오류 발생", e);
+            return RsData.of("500", "룸 목록 조회 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 룸에 참여합니다
+     */
+    @PostMapping("/{roomType}/{roomId}/join")
+    public RsData<UnifiedRoomResponse> joinRoom(@PathVariable String roomType,
+                                              @PathVariable String roomId,
+                                              @RequestParam String memberId) {
+        log.info("룸 참여 요청: roomType={}, roomId={}, memberId={}", roomType, roomId, memberId);
+        
+        try {
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            UnifiedRoomResponse response = roomService.joinRoom(roomId, memberId);
+            
+            log.info("룸 참여 성공: roomId={}, memberId={}", roomId, memberId);
+            return RsData.of("200", "룸 참여 성공", response);
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("룸 참여 실패 - 잘못된 요청: roomId={}, memberId={}, error={}", 
+                    roomId, memberId, e.getMessage());
+            return RsData.of("400", "잘못된 요청: " + e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("룸 참여 중 오류 발생: roomId={}, memberId={}", roomId, memberId, e);
+            return RsData.of("500", "룸 참여 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 룸에서 퇴장합니다
+     */
+    @PostMapping("/{roomType}/{roomId}/leave")
+    public RsData<UnifiedRoomResponse> leaveRoom(@PathVariable String roomType,
+                                               @PathVariable String roomId,
+                                               @RequestParam String memberId) {
+        log.info("룸 퇴장 요청: roomType={}, roomId={}, memberId={}", roomType, roomId, memberId);
+        
+        try {
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            UnifiedRoomResponse response = roomService.leaveRoom(roomId, memberId);
+            
+            log.info("룸 퇴장 성공: roomId={}, memberId={}", roomId, memberId);
+            return RsData.of("200", "룸 퇴장 성공", response);
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("룸 퇴장 실패 - 잘못된 요청: roomId={}, memberId={}, error={}", 
+                    roomId, memberId, e.getMessage());
+            return RsData.of("400", "잘못된 요청: " + e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("룸 퇴장 중 오류 발생: roomId={}, memberId={}", roomId, memberId, e);
+            return RsData.of("500", "룸 퇴장 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 사용자가 참여중인 룸 목록을 조회합니다
+     */
+    @GetMapping("/user/{memberId}")
+    public RsData<Map<String, List<UnifiedRoomResponse>>> getUserRooms(@PathVariable String memberId) {
+        log.debug("사용자 참여 룸 목록 조회 요청: memberId={}", memberId);
+        
+        try {
+            Map<String, List<UnifiedRoomResponse>> userRooms = roomServiceFactory
+                    .getSupportedRoomTypes()
+                    .stream()
+                    .collect(Collectors.toMap(
+                            RoomType::getCode,
+                            roomType -> {
+                                try {
+                                    RoomService service = roomServiceFactory.getService(roomType);
+                                    return service.getUserRooms(memberId);
+                                } catch (Exception e) {
+                                    log.warn("사용자 {} 의 {} 룸 목록 조회 중 오류: {}", 
+                                            memberId, roomType, e.getMessage());
+                                    return List.of();
+                                }
+                            }
+                    ));
+            
+            return RsData.of("200", "사용자 참여 룸 목록 조회 성공", userRooms);
+            
+        } catch (Exception e) {
+            log.error("사용자 참여 룸 목록 조회 중 오류 발생: memberId={}", memberId, e);
+            return RsData.of("500", "룸 목록 조회 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 룸 삭제 (관리자용)
+     */
+    @DeleteMapping("/{roomType}/{roomId}")
+    public RsData<String> deleteRoom(@PathVariable String roomType,
+                                   @PathVariable String roomId) {
+        log.info("룸 삭제 요청: roomType={}, roomId={}", roomType, roomId);
+        
+        try {
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            roomService.deleteRoom(roomId);
+            
+            log.info("룸 삭제 성공: roomId={}", roomId);
+            return RsData.of("200", "룸 삭제 성공", "SUCCESS");
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("룸 삭제 실패 - 잘못된 요청: roomId={}, error={}", roomId, e.getMessage());
+            return RsData.of("400", "잘못된 요청: " + e.getMessage(), null);
+        } catch (Exception e) {
+            log.error("룸 삭제 중 오류 발생: roomId={}", roomId, e);
+            return RsData.of("500", "룸 삭제 중 오류가 발생했습니다", null);
+        }
+    }
+
+    /**
+     * 팩토리 상태 정보 조회 (디버깅용)
+     */
+    @GetMapping("/factory/status")
+    public RsData<String> getFactoryStatus() {
+        try {
+            String status = roomServiceFactory.getFactoryStatus();
+            return RsData.of("200", "팩토리 상태 조회 성공", status);
+        } catch (Exception e) {
+            log.error("팩토리 상태 조회 중 오류 발생", e);
+            return RsData.of("500", "팩토리 상태 조회 중 오류가 발생했습니다", null);
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
 import org.com.dungeontalk.domain.room.service.RoomService;
 import org.com.dungeontalk.domain.room.service.RoomServiceFactory;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.common.UnifiedMessageType;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -43,11 +45,13 @@ public class UnifiedStompController {
             // 요청 유효성 검증
             request.validateByRoomType();
             
-            // roomType과 요청의 roomType 일치 확인
+            // roomType과 요청의 roomType 일치 확인 및 빌더로 새 객체 생성
             if (!roomType.equals(request.getRoomType().getCode())) {
                 log.warn("경로의 roomType({})과 요청의 roomType({})이 일치하지 않음", 
                         roomType, request.getRoomType().getCode());
-                request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
+                request = request.toBuilder()
+                        .roomType(RoomType.fromCode(roomType))
+                        .build();
             }
             
             // 해당 타입의 서비스 가져오기
@@ -81,10 +85,12 @@ public class UnifiedStompController {
                 roomType, request.getRoomId(), request.getSenderId());
         
         try {
-            // roomType 설정
-            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
-            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.SYSTEM);
-            request.setContent(request.getSenderId() + "님이 입장했습니다.");
+            // roomType 설정 및 빌더로 새 객체 생성
+            request = request.toBuilder()
+                    .roomType(RoomType.fromCode(roomType))
+                    .messageType(UnifiedMessageType.SYSTEM)
+                    .content(request.getSenderId() + "님이 입장했습니다.")
+                    .build();
             
             // 요청 유효성 검증
             request.validateByRoomType();
@@ -119,10 +125,12 @@ public class UnifiedStompController {
                 roomType, request.getRoomId(), request.getSenderId());
         
         try {
-            // roomType 설정
-            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
-            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.SYSTEM);
-            request.setContent(request.getSenderId() + "님이 퇴장했습니다.");
+            // roomType 설정 및 빌더로 새 객체 생성
+            request = request.toBuilder()
+                    .roomType(RoomType.fromCode(roomType))
+                    .messageType(UnifiedMessageType.SYSTEM)
+                    .content(request.getSenderId() + "님이 퇴장했습니다.")
+                    .build();
             
             // 요청 유효성 검증
             request.validateByRoomType();
@@ -155,12 +163,12 @@ public class UnifiedStompController {
         log.debug("AI 게임 턴 시작: roomId={}", request.getRoomId());
         
         try {
-            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.AI_GAME);
-            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.GAME_STATE);
-            
-            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
-                request.setContent("새로운 턴이 시작되었습니다.");
-            }
+            request = request.toBuilder()
+                    .roomType(RoomType.AI_GAME)
+                    .messageType(UnifiedMessageType.GAME_STATE)
+                    .content(request.getContent() != null && !request.getContent().trim().isEmpty() 
+                            ? request.getContent() : "새로운 턴이 시작되었습니다.")
+                    .build();
             
             RoomService roomService = roomServiceFactory.getService("ai");
             roomService.processMessage(request);
@@ -178,12 +186,12 @@ public class UnifiedStompController {
         log.debug("AI 게임 턴 종료: roomId={}", request.getRoomId());
         
         try {
-            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.AI_GAME);
-            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.GAME_STATE);
-            
-            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
-                request.setContent("턴이 종료되었습니다.");
-            }
+            request = request.toBuilder()
+                    .roomType(RoomType.AI_GAME)
+                    .messageType(UnifiedMessageType.GAME_STATE)
+                    .content(request.getContent() != null && !request.getContent().trim().isEmpty() 
+                            ? request.getContent() : "턴이 종료되었습니다.")
+                    .build();
             
             RoomService roomService = roomServiceFactory.getService("ai");
             roomService.processMessage(request);

--- a/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
@@ -1,0 +1,195 @@
+package org.com.dungeontalk.domain.room.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
+import org.com.dungeontalk.domain.room.service.RoomService;
+import org.com.dungeontalk.domain.room.service.RoomServiceFactory;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.stereotype.Controller;
+
+import jakarta.validation.Valid;
+
+/**
+ * 통합된 STOMP 컨트롤러
+ * AI 채팅과 플레이어 채팅의 WebSocket 메시지를 통합 처리
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class UnifiedStompController {
+
+    private final RoomServiceFactory roomServiceFactory;
+
+    /**
+     * 통합된 메시지 전송 엔드포인트
+     * 
+     * 클라이언트는 /pub/room/{roomType}/send 로 메시지를 발행
+     * roomType: "ai" (AI 게임) 또는 "chat" (플레이어 채팅)
+     * 
+     * 예시:
+     * - AI 게임 메시지: /pub/room/ai/send
+     * - 플레이어 채팅: /pub/room/chat/send
+     */
+    @MessageMapping("/room/{roomType}/send")
+    public void sendMessage(@DestinationVariable String roomType, 
+                          @Valid @Payload UnifiedMessageRequest request) {
+        log.debug("통합 메시지 수신: roomType={}, roomId={}, senderId={}, messageType={}", 
+                roomType, request.getRoomId(), request.getSenderId(), request.getMessageType());
+        
+        try {
+            // 요청 유효성 검증
+            request.validateByRoomType();
+            
+            // roomType과 요청의 roomType 일치 확인
+            if (!roomType.equals(request.getRoomType().getCode())) {
+                log.warn("경로의 roomType({})과 요청의 roomType({})이 일치하지 않음", 
+                        roomType, request.getRoomType().getCode());
+                request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
+            }
+            
+            // 해당 타입의 서비스 가져오기
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            
+            // 메시지 처리
+            roomService.processMessage(request);
+            
+            log.debug("메시지 처리 완료: roomType={}, roomId={}, messageType={}", 
+                    roomType, request.getRoomId(), request.getMessageType());
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("메시지 처리 실패 - 잘못된 요청: roomType={}, error={}", roomType, e.getMessage());
+            // TODO: 클라이언트에게 에러 메시지 전송
+        } catch (Exception e) {
+            log.error("메시지 처리 중 오류 발생: roomType={}, roomId={}", 
+                    roomType, request.getRoomId(), e);
+            // TODO: 클라이언트에게 에러 메시지 전송
+        }
+    }
+
+    /**
+     * 통합된 룸 입장 엔드포인트
+     * 
+     * 클라이언트는 /pub/room/{roomType}/join 으로 입장 요청을 발행
+     */
+    @MessageMapping("/room/{roomType}/join")
+    public void joinRoom(@DestinationVariable String roomType,
+                        @Valid @Payload UnifiedMessageRequest request) {
+        log.info("룸 입장 요청: roomType={}, roomId={}, senderId={}", 
+                roomType, request.getRoomId(), request.getSenderId());
+        
+        try {
+            // roomType 설정
+            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
+            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.SYSTEM);
+            request.setContent(request.getSenderId() + "님이 입장했습니다.");
+            
+            // 요청 유효성 검증
+            request.validateByRoomType();
+            
+            // 해당 타입의 서비스 가져오기
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            
+            // 룸 입장 처리
+            roomService.joinRoom(request.getRoomId(), request.getSenderId());
+            
+            // 입장 메시지 전송
+            roomService.processMessage(request);
+            
+            log.info("룸 입장 완료: roomType={}, roomId={}, senderId={}", 
+                    roomType, request.getRoomId(), request.getSenderId());
+            
+        } catch (Exception e) {
+            log.error("룸 입장 중 오류 발생: roomType={}, roomId={}, senderId={}", 
+                    roomType, request.getRoomId(), request.getSenderId(), e);
+        }
+    }
+
+    /**
+     * 통합된 룸 퇴장 엔드포인트
+     * 
+     * 클라이언트는 /pub/room/{roomType}/leave 로 퇴장 요청을 발행
+     */
+    @MessageMapping("/room/{roomType}/leave")
+    public void leaveRoom(@DestinationVariable String roomType,
+                         @Valid @Payload UnifiedMessageRequest request) {
+        log.info("룸 퇴장 요청: roomType={}, roomId={}, senderId={}", 
+                roomType, request.getRoomId(), request.getSenderId());
+        
+        try {
+            // roomType 설정
+            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.fromCode(roomType));
+            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.SYSTEM);
+            request.setContent(request.getSenderId() + "님이 퇴장했습니다.");
+            
+            // 요청 유효성 검증
+            request.validateByRoomType();
+            
+            // 해당 타입의 서비스 가져오기
+            RoomService roomService = roomServiceFactory.getService(roomType);
+            
+            // 퇴장 메시지 전송 (퇴장 전에)
+            roomService.processMessage(request);
+            
+            // 룸 퇴장 처리
+            roomService.leaveRoom(request.getRoomId(), request.getSenderId());
+            
+            log.info("룸 퇴장 완료: roomType={}, roomId={}, senderId={}", 
+                    roomType, request.getRoomId(), request.getSenderId());
+            
+        } catch (Exception e) {
+            log.error("룸 퇴장 중 오류 발생: roomType={}, roomId={}, senderId={}", 
+                    roomType, request.getRoomId(), request.getSenderId(), e);
+        }
+    }
+
+    // === AI 게임 전용 엔드포인트 (하위 호환성) ===
+
+    /**
+     * AI 게임 턴 시작 (AI 게임 전용)
+     */
+    @MessageMapping("/room/ai/turn/start")
+    public void startTurn(@Valid @Payload UnifiedMessageRequest request) {
+        log.debug("AI 게임 턴 시작: roomId={}", request.getRoomId());
+        
+        try {
+            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.AI_GAME);
+            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.GAME_STATE);
+            
+            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+                request.setContent("새로운 턴이 시작되었습니다.");
+            }
+            
+            RoomService roomService = roomServiceFactory.getService("ai");
+            roomService.processMessage(request);
+            
+        } catch (Exception e) {
+            log.error("AI 게임 턴 시작 중 오류 발생: roomId={}", request.getRoomId(), e);
+        }
+    }
+
+    /**
+     * AI 게임 턴 종료 (AI 게임 전용)
+     */
+    @MessageMapping("/room/ai/turn/end")
+    public void endTurn(@Valid @Payload UnifiedMessageRequest request) {
+        log.debug("AI 게임 턴 종료: roomId={}", request.getRoomId());
+        
+        try {
+            request.setRoomType(org.com.dungeontalk.domain.room.common.RoomType.AI_GAME);
+            request.setMessageType(org.com.dungeontalk.domain.room.common.UnifiedMessageType.GAME_STATE);
+            
+            if (request.getContent() == null || request.getContent().trim().isEmpty()) {
+                request.setContent("턴이 종료되었습니다.");
+            }
+            
+            RoomService roomService = roomServiceFactory.getService("ai");
+            roomService.processMessage(request);
+            
+        } catch (Exception e) {
+            log.error("AI 게임 턴 종료 중 오류 발생: roomId={}", request.getRoomId(), e);
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedMessageRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedMessageRequest.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.com.dungeontalk.domain.room.common.RoomType;
 import org.com.dungeontalk.domain.room.common.UnifiedMessageType;
 
@@ -16,10 +15,9 @@ import jakarta.validation.constraints.NotNull;
  * AI 채팅과 플레이어 채팅의 메시지 요청을 통합
  */
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class UnifiedMessageRequest {
 
     // === 공통 필드 ===
@@ -117,79 +115,63 @@ public class UnifiedMessageRequest {
     }
 
     /**
-     * AI 게임용 필드 설정
+     * AI 게임 메시지 생성을 위한 빌더
      */
-    public void setAiGameFields(String aiGameRoomId, String gameActionType, Integer turnNumber) {
-        this.aiGameRoomId = aiGameRoomId;
-        this.gameActionType = gameActionType;
-        this.turnNumber = turnNumber;
+    public static UnifiedMessageRequestBuilder aiGameMessage() {
+        return UnifiedMessageRequest.builder()
+                .roomType(RoomType.AI_GAME)
+                .messageType(UnifiedMessageType.USER);
     }
 
     /**
-     * 플레이어 채팅용 필드 설정
+     * 플레이어 채팅 메시지 생성을 위한 빌더
      */
-    public void setPlayerChatFields(String chatRoomId, String senderNickname) {
-        this.chatRoomId = chatRoomId;
-        this.senderNickname = senderNickname;
+    public static UnifiedMessageRequestBuilder playerChatMessage() {
+        return UnifiedMessageRequest.builder()
+                .roomType(RoomType.PLAYER_CHAT)
+                .messageType(UnifiedMessageType.USER);
     }
 
     /**
-     * 룸 타입에 따른 자동 필드 설정
+     * 시스템 메시지 생성을 위한 빌더
      */
-    public void autoSetFieldsByRoomType() {
-        if (isAiGameMessage() && aiGameRoomId == null) {
-            this.aiGameRoomId = this.roomId;
-        } else if (isPlayerChatMessage() && chatRoomId == null) {
-            this.chatRoomId = this.roomId;
-        }
+    public static UnifiedMessageRequestBuilder systemMessage() {
+        return UnifiedMessageRequest.builder()
+                .messageType(UnifiedMessageType.SYSTEM);
     }
 
     /**
-     * 유효성 검증 - AI 게임 메시지
+     * 자동으로 roomId에 맞는 전용 필드 설정
      */
-    public void validateForAiGame() {
-        if (!isAiGameMessage()) {
-            return;
-        }
-        
-        if (aiGameRoomId == null || aiGameRoomId.trim().isEmpty()) {
-            this.aiGameRoomId = this.roomId;
-        }
-        
-        // AI 게임 메시지 특별 검증 로직
-        if (messageType.isPlayerChatType()) {
-            throw new IllegalArgumentException("AI 게임에서는 플레이어 채팅 전용 메시지 타입을 사용할 수 없습니다: " + messageType);
-        }
+    public UnifiedMessageRequest withAutoFields() {
+        return this.toBuilder()
+                .aiGameRoomId(isAiGameMessage() ? roomId : aiGameRoomId)
+                .chatRoomId(isPlayerChatMessage() ? roomId : chatRoomId)
+                .build();
     }
 
     /**
-     * 유효성 검증 - 플레이어 채팅 메시지
-     */
-    public void validateForPlayerChat() {
-        if (!isPlayerChatMessage()) {
-            return;
-        }
-        
-        if (chatRoomId == null || chatRoomId.trim().isEmpty()) {
-            this.chatRoomId = this.roomId;
-        }
-        
-        // 플레이어 채팅 메시지 특별 검증 로직
-        if (messageType.isAiGameType()) {
-            throw new IllegalArgumentException("플레이어 채팅에서는 AI 게임 전용 메시지 타입을 사용할 수 없습니다: " + messageType);
-        }
-    }
-
-    /**
-     * 룸 타입에 따른 자동 검증
+     * 룸 타입에 따른 유효성 검증
      */
     public void validateByRoomType() {
-        autoSetFieldsByRoomType();
+        if (roomType == null) {
+            throw new IllegalArgumentException("룸 타입은 필수입니다");
+        }
         
-        if (isAiGameMessage()) {
-            validateForAiGame();
-        } else if (isPlayerChatMessage()) {
-            validateForPlayerChat();
+        if (messageType == null) {
+            throw new IllegalArgumentException("메시지 타입은 필수입니다");
+        }
+        
+        if (roomId == null || roomId.trim().isEmpty()) {
+            throw new IllegalArgumentException("룸 ID는 필수입니다");
+        }
+        
+        if (senderId == null || senderId.trim().isEmpty()) {
+            throw new IllegalArgumentException("발신자 ID는 필수입니다");
+        }
+        
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("메시지 내용은 필수입니다");
         }
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedMessageRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedMessageRequest.java
@@ -1,0 +1,195 @@
+package org.com.dungeontalk.domain.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.common.UnifiedMessageType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 통합된 메시지 요청 DTO
+ * AI 채팅과 플레이어 채팅의 메시지 요청을 통합
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UnifiedMessageRequest {
+
+    // === 공통 필드 ===
+    
+    /**
+     * 룸 ID (필수)
+     */
+    @NotBlank(message = "룸 ID는 필수입니다")
+    private String roomId;
+    
+    /**
+     * 룸 타입 (필수)
+     */
+    @NotNull(message = "룸 타입은 필수입니다")
+    private RoomType roomType;
+    
+    /**
+     * 발신자 ID (필수)
+     */
+    @NotBlank(message = "발신자 ID는 필수입니다")
+    private String senderId;
+    
+    /**
+     * 메시지 타입 (필수)
+     */
+    @NotNull(message = "메시지 타입은 필수입니다")
+    private UnifiedMessageType messageType;
+    
+    /**
+     * 메시지 내용 (필수)
+     */
+    @NotBlank(message = "메시지 내용은 필수입니다")
+    private String content;
+    
+    /**
+     * 메시지 메타데이터 (선택)
+     */
+    private String metadata;
+
+    // === AI 게임 전용 필드 ===
+    
+    /**
+     * AI 게임룸 ID (AI 메시지용)
+     */
+    private String aiGameRoomId;
+    
+    /**
+     * 게임 액션 타입 (AI 게임용)
+     */
+    private String gameActionType;
+    
+    /**
+     * 턴 번호 (AI 게임용)
+     */
+    private Integer turnNumber;
+
+    // === 플레이어 채팅 전용 필드 ===
+    
+    /**
+     * 채팅룸 ID (플레이어 채팅용)
+     */
+    private String chatRoomId;
+    
+    /**
+     * 발신자 닉네임 (플레이어 채팅용)
+     */
+    private String senderNickname;
+
+    /**
+     * AI 게임 메시지인지 확인
+     */
+    public boolean isAiGameMessage() {
+        return roomType == RoomType.AI_GAME;
+    }
+
+    /**
+     * 플레이어 채팅 메시지인지 확인
+     */
+    public boolean isPlayerChatMessage() {
+        return roomType == RoomType.PLAYER_CHAT;
+    }
+
+    /**
+     * 시스템 메시지인지 확인
+     */
+    public boolean isSystemMessage() {
+        return messageType == UnifiedMessageType.SYSTEM;
+    }
+
+    /**
+     * 사용자 메시지인지 확인
+     */
+    public boolean isUserMessage() {
+        return messageType == UnifiedMessageType.USER;
+    }
+
+    /**
+     * AI 게임용 필드 설정
+     */
+    public void setAiGameFields(String aiGameRoomId, String gameActionType, Integer turnNumber) {
+        this.aiGameRoomId = aiGameRoomId;
+        this.gameActionType = gameActionType;
+        this.turnNumber = turnNumber;
+    }
+
+    /**
+     * 플레이어 채팅용 필드 설정
+     */
+    public void setPlayerChatFields(String chatRoomId, String senderNickname) {
+        this.chatRoomId = chatRoomId;
+        this.senderNickname = senderNickname;
+    }
+
+    /**
+     * 룸 타입에 따른 자동 필드 설정
+     */
+    public void autoSetFieldsByRoomType() {
+        if (isAiGameMessage() && aiGameRoomId == null) {
+            this.aiGameRoomId = this.roomId;
+        } else if (isPlayerChatMessage() && chatRoomId == null) {
+            this.chatRoomId = this.roomId;
+        }
+    }
+
+    /**
+     * 유효성 검증 - AI 게임 메시지
+     */
+    public void validateForAiGame() {
+        if (!isAiGameMessage()) {
+            return;
+        }
+        
+        if (aiGameRoomId == null || aiGameRoomId.trim().isEmpty()) {
+            this.aiGameRoomId = this.roomId;
+        }
+        
+        // AI 게임 메시지 특별 검증 로직
+        if (messageType.isPlayerChatType()) {
+            throw new IllegalArgumentException("AI 게임에서는 플레이어 채팅 전용 메시지 타입을 사용할 수 없습니다: " + messageType);
+        }
+    }
+
+    /**
+     * 유효성 검증 - 플레이어 채팅 메시지
+     */
+    public void validateForPlayerChat() {
+        if (!isPlayerChatMessage()) {
+            return;
+        }
+        
+        if (chatRoomId == null || chatRoomId.trim().isEmpty()) {
+            this.chatRoomId = this.roomId;
+        }
+        
+        // 플레이어 채팅 메시지 특별 검증 로직
+        if (messageType.isAiGameType()) {
+            throw new IllegalArgumentException("플레이어 채팅에서는 AI 게임 전용 메시지 타입을 사용할 수 없습니다: " + messageType);
+        }
+    }
+
+    /**
+     * 룸 타입에 따른 자동 검증
+     */
+    public void validateByRoomType() {
+        autoSetFieldsByRoomType();
+        
+        if (isAiGameMessage()) {
+            validateForAiGame();
+        } else if (isPlayerChatMessage()) {
+            validateForPlayerChat();
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomRequest.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.com.dungeontalk.domain.room.common.RoomType;
 import org.com.dungeontalk.domain.chat.common.ChatMode;
 
@@ -18,7 +17,6 @@ import java.util.List;
  * AI 게임룸과 플레이어 채팅룸 생성 요청을 통합
  */
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -99,41 +97,37 @@ public class UnifiedRoomRequest {
     }
 
     /**
-     * 유효성 검증 - AI 게임룸 필수 필드 체크
+     * 유효성 검증 및 기본값 설정을 위한 빌더 생성
      */
-    public void validateForAiGameRoom() {
-        if (!isAiGameRoom()) {
-            return;
-        }
-        
-        // AI 게임룸 특별 검증 로직이 필요하면 여기에 추가
-        if (maxParticipants == null) {
-            maxParticipants = 3; // AI 게임룸 기본값
-        }
+    public static UnifiedRoomRequestBuilder aiGameRoom() {
+        return UnifiedRoomRequest.builder()
+                .roomType(RoomType.AI_GAME)
+                .maxParticipants(3);
     }
 
     /**
-     * 유효성 검증 - 플레이어 채팅룸 필수 필드 체크
+     * 플레이어 채팅룸 생성을 위한 빌더
      */
-    public void validateForPlayerChatRoom() {
-        if (!isPlayerChatRoom()) {
-            return;
-        }
-        
-        // 플레이어 채팅룸 특별 검증 로직이 필요하면 여기에 추가
-        if (chatMode == null) {
-            chatMode = ChatMode.MULTI; // 기본값
-        }
+    public static UnifiedRoomRequestBuilder playerChatRoom() {
+        return UnifiedRoomRequest.builder()
+                .roomType(RoomType.PLAYER_CHAT)
+                .chatMode(ChatMode.MULTI);
     }
 
     /**
-     * 룸 타입에 따른 자동 검증
+     * 룸 타입에 따른 유효성 검증
      */
     public void validateByRoomType() {
-        if (isAiGameRoom()) {
-            validateForAiGameRoom();
-        } else if (isPlayerChatRoom()) {
-            validateForPlayerChatRoom();
+        if (roomType == null) {
+            throw new IllegalArgumentException("룸 타입은 필수입니다");
+        }
+        
+        if (isAiGameRoom() && maxParticipants == null) {
+            throw new IllegalArgumentException("AI 게임룸은 최대 참여자 수가 필요합니다");
+        }
+        
+        if (isPlayerChatRoom() && chatMode == null) {
+            throw new IllegalArgumentException("플레이어 채팅룸은 채팅 모드가 필요합니다");
         }
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomRequest.java
@@ -1,0 +1,139 @@
+package org.com.dungeontalk.domain.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.chat.common.ChatMode;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+
+/**
+ * 통합된 룸 생성 요청 DTO
+ * AI 게임룸과 플레이어 채팅룸 생성 요청을 통합
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UnifiedRoomRequest {
+
+    // === 공통 필드 ===
+    
+    /**
+     * 룸 타입 (필수)
+     */
+    @NotNull(message = "룸 타입은 필수입니다")
+    private RoomType roomType;
+    
+    /**
+     * 룸 이름 (필수)
+     */
+    @NotBlank(message = "룸 이름은 필수입니다")
+    private String roomName;
+    
+    /**
+     * 룸 설명 (선택)
+     */
+    private String description;
+    
+    /**
+     * 최대 참여자 수 (선택, 기본값은 각 타입별 기본값 사용)
+     */
+    @Positive(message = "최대 참여자 수는 양수여야 합니다")
+    private Integer maxParticipants;
+    
+    /**
+     * 생성자 ID (필수)
+     */
+    @NotBlank(message = "생성자 ID는 필수입니다")
+    private String creatorId;
+    
+    /**
+     * 초기 참여자 ID 목록 (선택)
+     */
+    private List<String> participantIds;
+
+    // === AI 게임룸 전용 필드 ===
+    
+    /**
+     * 연결된 게임 ID (AI 게임룸용, 선택)
+     */
+    private String gameId;
+    
+    /**
+     * 게임 설정 JSON (AI 게임룸용, 선택)
+     */
+    private String gameSettings;
+
+    // === 플레이어 채팅룸 전용 필드 ===
+    
+    /**
+     * 채팅 모드 (플레이어 채팅룸용, 선택)
+     */
+    private ChatMode chatMode;
+    
+    /**
+     * 최대 용량 (플레이어 채팅룸용, 선택)
+     */
+    private Long maxCapacity;
+
+    /**
+     * AI 게임룸 생성 요청인지 확인
+     */
+    public boolean isAiGameRoom() {
+        return roomType == RoomType.AI_GAME;
+    }
+
+    /**
+     * 플레이어 채팅룸 생성 요청인지 확인
+     */
+    public boolean isPlayerChatRoom() {
+        return roomType == RoomType.PLAYER_CHAT;
+    }
+
+    /**
+     * 유효성 검증 - AI 게임룸 필수 필드 체크
+     */
+    public void validateForAiGameRoom() {
+        if (!isAiGameRoom()) {
+            return;
+        }
+        
+        // AI 게임룸 특별 검증 로직이 필요하면 여기에 추가
+        if (maxParticipants == null) {
+            maxParticipants = 3; // AI 게임룸 기본값
+        }
+    }
+
+    /**
+     * 유효성 검증 - 플레이어 채팅룸 필수 필드 체크
+     */
+    public void validateForPlayerChatRoom() {
+        if (!isPlayerChatRoom()) {
+            return;
+        }
+        
+        // 플레이어 채팅룸 특별 검증 로직이 필요하면 여기에 추가
+        if (chatMode == null) {
+            chatMode = ChatMode.MULTI; // 기본값
+        }
+    }
+
+    /**
+     * 룸 타입에 따른 자동 검증
+     */
+    public void validateByRoomType() {
+        if (isAiGameRoom()) {
+            validateForAiGameRoom();
+        } else if (isPlayerChatRoom()) {
+            validateForPlayerChatRoom();
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomResponse.java
@@ -7,9 +7,9 @@ import lombok.NoArgsConstructor;
 import org.com.dungeontalk.domain.room.common.RoomType;
 import org.com.dungeontalk.domain.room.common.UnifiedRoomStatus;
 import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
+import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
 import org.com.dungeontalk.domain.chat.dto.ChatRoomDto;
 
-import java.time.LocalDateTime;
 import java.time.Instant;
 import java.util.List;
 
@@ -66,14 +66,14 @@ public class UnifiedRoomResponse {
     private List<String> participantIds;
     
     /**
-     * 생성 시간
+     * 생성 시간 (UTC)
      */
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     
     /**
-     * 수정 시간
+     * 수정 시간 (UTC)
      */
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     // === AI 게임룸 전용 필드 ===
     
@@ -93,9 +93,9 @@ public class UnifiedRoomResponse {
     private String gameSettings;
     
     /**
-     * 마지막 활동 시간
+     * 마지막 활동 시간 (UTC)
      */
-    private LocalDateTime lastActivity;
+    private Instant lastActivity;
 
     // === 플레이어 채팅룸 전용 필드 ===
     
@@ -144,11 +144,13 @@ public class UnifiedRoomResponse {
                 .currentParticipants(aiResponse.getCurrentParticipantCount())
                 .maxParticipants(aiResponse.getMaxParticipants())
                 .participantIds(aiResponse.getParticipants())
-                .createdAt(aiResponse.getCreatedAt())
+                .createdAt(aiResponse.getCreatedAt() != null ? 
+                          aiResponse.getCreatedAt().atZone(java.time.ZoneOffset.UTC).toInstant() : null)
                 // AI 게임룸 전용 필드
                 .gameId(aiResponse.getGameId())
                 .currentTurn(aiResponse.getCurrentTurn())
-                .lastActivity(aiResponse.getLastActivity())
+                .lastActivity(aiResponse.getLastActivity() != null ? 
+                          aiResponse.getLastActivity().atZone(java.time.ZoneOffset.UTC).toInstant() : null)
                 .build();
     }
 
@@ -161,17 +163,15 @@ public class UnifiedRoomResponse {
                 .roomType(RoomType.PLAYER_CHAT)
                 .roomName(chatResponse.getRoomName())
                 .status(UnifiedRoomStatus.CHAT_AVAILABLE) // 기본 상태
-                .createdAt(chatResponse.getCreatedAt() != null ? 
-                          LocalDateTime.ofInstant(chatResponse.getCreatedAt(), java.time.ZoneOffset.UTC) : null)
-                .updatedAt(chatResponse.getUpdatedAt() != null ? 
-                          LocalDateTime.ofInstant(chatResponse.getUpdatedAt(), java.time.ZoneOffset.UTC) : null)
+                .createdAt(chatResponse.getCreatedAt())
+                .updatedAt(chatResponse.getUpdatedAt())
                 .build();
     }
 
     /**
      * AI 게임 상태를 통합 상태로 매핑
      */
-    private static UnifiedRoomStatus mapAiGameStatus(org.com.dungeontalk.domain.aichat.common.AiGameStatus aiStatus) {
+    private static UnifiedRoomStatus mapAiGameStatus(AiGameStatus aiStatus) {
         if (aiStatus == null) {
             return UnifiedRoomStatus.CREATED;
         }

--- a/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/dto/UnifiedRoomResponse.java
@@ -1,0 +1,194 @@
+package org.com.dungeontalk.domain.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.com.dungeontalk.domain.room.common.UnifiedRoomStatus;
+import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
+import org.com.dungeontalk.domain.chat.dto.ChatRoomDto;
+
+import java.time.LocalDateTime;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 통합된 룸 응답 DTO
+ * AI 게임룸과 플레이어 채팅룸 응답을 통합
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UnifiedRoomResponse {
+
+    // === 공통 필드 ===
+    
+    /**
+     * 룸 ID
+     */
+    private String roomId;
+    
+    /**
+     * 룸 타입
+     */
+    private RoomType roomType;
+    
+    /**
+     * 룸 이름
+     */
+    private String roomName;
+    
+    /**
+     * 룸 설명
+     */
+    private String description;
+    
+    /**
+     * 룸 상태
+     */
+    private UnifiedRoomStatus status;
+    
+    /**
+     * 현재 참여자 수
+     */
+    private int currentParticipants;
+    
+    /**
+     * 최대 참여자 수
+     */
+    private int maxParticipants;
+    
+    /**
+     * 참여자 ID 목록
+     */
+    private List<String> participantIds;
+    
+    /**
+     * 생성 시간
+     */
+    private LocalDateTime createdAt;
+    
+    /**
+     * 수정 시간
+     */
+    private LocalDateTime updatedAt;
+
+    // === AI 게임룸 전용 필드 ===
+    
+    /**
+     * 연결된 게임 ID
+     */
+    private String gameId;
+    
+    /**
+     * 현재 턴 번호
+     */
+    private Integer currentTurn;
+    
+    /**
+     * 게임 설정
+     */
+    private String gameSettings;
+    
+    /**
+     * 마지막 활동 시간
+     */
+    private LocalDateTime lastActivity;
+
+    // === 플레이어 채팅룸 전용 필드 ===
+    
+    /**
+     * 최대 용량 (플레이어 채팅룸용)
+     */
+    private Long maxCapacity;
+    
+    /**
+     * 현재 온라인 사용자 수
+     */
+    private Long onlineUserCount;
+
+    /**
+     * AI 게임룸 응답인지 확인
+     */
+    public boolean isAiGameRoom() {
+        return roomType == RoomType.AI_GAME;
+    }
+
+    /**
+     * 플레이어 채팅룸 응답인지 확인
+     */
+    public boolean isPlayerChatRoom() {
+        return roomType == RoomType.PLAYER_CHAT;
+    }
+
+    /**
+     * 룸이 입장 가능한지 확인
+     */
+    public boolean isJoinable() {
+        return status != null && status.isUsable() && 
+               currentParticipants < maxParticipants;
+    }
+
+    /**
+     * AI 게임룸 응답으로부터 통합 응답 생성
+     */
+    public static UnifiedRoomResponse fromAiGameRoom(AiGameRoomResponse aiResponse) {
+        return UnifiedRoomResponse.builder()
+                .roomId(aiResponse.getId())
+                .roomType(RoomType.AI_GAME)
+                .roomName(aiResponse.getRoomName())
+                .description(aiResponse.getDescription())
+                .status(mapAiGameStatus(aiResponse.getStatus()))
+                .currentParticipants(aiResponse.getCurrentParticipantCount())
+                .maxParticipants(aiResponse.getMaxParticipants())
+                .participantIds(aiResponse.getParticipants())
+                .createdAt(aiResponse.getCreatedAt())
+                // AI 게임룸 전용 필드
+                .gameId(aiResponse.getGameId())
+                .currentTurn(aiResponse.getCurrentTurn())
+                .lastActivity(aiResponse.getLastActivity())
+                .build();
+    }
+
+    /**
+     * 플레이어 채팅룸 응답으로부터 통합 응답 생성
+     */
+    public static UnifiedRoomResponse fromPlayerChatRoom(ChatRoomDto chatResponse) {
+        return UnifiedRoomResponse.builder()
+                .roomId(chatResponse.getId())
+                .roomType(RoomType.PLAYER_CHAT)
+                .roomName(chatResponse.getRoomName())
+                .status(UnifiedRoomStatus.CHAT_AVAILABLE) // 기본 상태
+                .createdAt(chatResponse.getCreatedAt() != null ? 
+                          LocalDateTime.ofInstant(chatResponse.getCreatedAt(), java.time.ZoneOffset.UTC) : null)
+                .updatedAt(chatResponse.getUpdatedAt() != null ? 
+                          LocalDateTime.ofInstant(chatResponse.getUpdatedAt(), java.time.ZoneOffset.UTC) : null)
+                .build();
+    }
+
+    /**
+     * AI 게임 상태를 통합 상태로 매핑
+     */
+    private static UnifiedRoomStatus mapAiGameStatus(org.com.dungeontalk.domain.aichat.common.AiGameStatus aiStatus) {
+        if (aiStatus == null) {
+            return UnifiedRoomStatus.CREATED;
+        }
+        
+        switch (aiStatus) {
+            case CREATED:
+                return UnifiedRoomStatus.CREATED;
+            case ACTIVE:
+                return UnifiedRoomStatus.ACTIVE;
+            case PAUSED:
+                return UnifiedRoomStatus.PAUSED;
+            case COMPLETED:
+                return UnifiedRoomStatus.COMPLETED;
+            case ERROR:
+                return UnifiedRoomStatus.ERROR;
+            default:
+                return UnifiedRoomStatus.CREATED;
+        }
+    }
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/service/RoomService.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/service/RoomService.java
@@ -1,0 +1,140 @@
+package org.com.dungeontalk.domain.room.service;
+
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomRequest;
+import org.com.dungeontalk.domain.room.dto.UnifiedRoomResponse;
+import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
+import org.com.dungeontalk.domain.room.common.RoomType;
+
+import java.util.List;
+
+/**
+ * 통합된 룸 서비스 인터페이스
+ * AI 게임룸과 플레이어 채팅룸의 공통 기능을 정의
+ */
+public interface RoomService {
+
+    /**
+     * 이 서비스가 지원하는 룸 타입
+     */
+    RoomType getSupportedRoomType();
+
+    // === 룸 관리 기능 ===
+
+    /**
+     * 새로운 룸을 생성합니다
+     * 
+     * @param request 룸 생성 요청 정보
+     * @return 생성된 룸 정보
+     */
+    UnifiedRoomResponse createRoom(UnifiedRoomRequest request);
+
+    /**
+     * 룸 정보를 조회합니다
+     * 
+     * @param roomId 룸 ID
+     * @return 룸 정보
+     */
+    UnifiedRoomResponse getRoom(String roomId);
+
+    /**
+     * 룸을 삭제합니다
+     * 
+     * @param roomId 룸 ID
+     */
+    void deleteRoom(String roomId);
+
+    /**
+     * 입장 가능한 룸 목록을 조회합니다
+     * 
+     * @return 입장 가능한 룸 목록
+     */
+    List<UnifiedRoomResponse> getAvailableRooms();
+
+    // === 참여자 관리 기능 ===
+
+    /**
+     * 룸에 참여합니다
+     * 
+     * @param roomId 룸 ID
+     * @param memberId 참여자 ID
+     * @return 업데이트된 룸 정보
+     */
+    UnifiedRoomResponse joinRoom(String roomId, String memberId);
+
+    /**
+     * 룸에서 퇴장합니다
+     * 
+     * @param roomId 룸 ID
+     * @param memberId 참여자 ID
+     * @return 업데이트된 룸 정보
+     */
+    UnifiedRoomResponse leaveRoom(String roomId, String memberId);
+
+    /**
+     * 특정 사용자가 참여중인 룸 목록을 조회합니다
+     * 
+     * @param memberId 사용자 ID
+     * @return 참여중인 룸 목록
+     */
+    List<UnifiedRoomResponse> getUserRooms(String memberId);
+
+    // === 메시지 처리 기능 ===
+
+    /**
+     * 메시지를 처리합니다
+     * 
+     * @param request 메시지 요청 정보
+     */
+    void processMessage(UnifiedMessageRequest request);
+
+    /**
+     * 룸에 시스템 메시지를 전송합니다
+     * 
+     * @param roomId 룸 ID
+     * @param message 메시지 내용
+     */
+    void sendSystemMessage(String roomId, String message);
+
+    // === 상태 관리 기능 ===
+
+    /**
+     * 룸이 존재하는지 확인합니다
+     * 
+     * @param roomId 룸 ID
+     * @return 존재 여부
+     */
+    boolean existsRoom(String roomId);
+
+    /**
+     * 룸이 활성 상태인지 확인합니다
+     * 
+     * @param roomId 룸 ID
+     * @return 활성 상태 여부
+     */
+    boolean isRoomActive(String roomId);
+
+    /**
+     * 룸에 입장 가능한지 확인합니다
+     * 
+     * @param roomId 룸 ID
+     * @param memberId 참여하려는 사용자 ID
+     * @return 입장 가능 여부
+     */
+    boolean canJoinRoom(String roomId, String memberId);
+
+    /**
+     * 룸의 현재 참여자 수를 조회합니다
+     * 
+     * @param roomId 룸 ID
+     * @return 현재 참여자 수
+     */
+    int getCurrentParticipantCount(String roomId);
+
+    /**
+     * 룸의 최대 참여자 수를 조회합니다
+     * 
+     * @param roomId 룸 ID
+     * @return 최대 참여자 수
+     */
+    int getMaxParticipantCount(String roomId);
+}

--- a/src/main/java/org/com/dungeontalk/domain/room/service/RoomServiceFactory.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/service/RoomServiceFactory.java
@@ -1,0 +1,161 @@
+package org.com.dungeontalk.domain.room.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 룸 서비스 팩토리
+ * 룸 타입에 따라 적절한 RoomService 구현체를 반환
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomServiceFactory {
+
+    private final List<RoomService> roomServices;
+    private Map<RoomType, RoomService> serviceMap;
+
+    /**
+     * 팩토리 초기화
+     * 등록된 모든 RoomService 구현체를 맵에 저장
+     */
+    private void initializeServiceMap() {
+        if (serviceMap == null) {
+            serviceMap = roomServices.stream()
+                    .collect(Collectors.toMap(
+                            RoomService::getSupportedRoomType,
+                            Function.identity(),
+                            (existing, replacement) -> {
+                                log.warn("중복된 RoomType 발견: {}. 기존: {}, 새로운: {}", 
+                                        existing.getSupportedRoomType(), 
+                                        existing.getClass().getSimpleName(), 
+                                        replacement.getClass().getSimpleName());
+                                return replacement; // 나중에 등록된 것으로 대체
+                            }
+                    ));
+            
+            log.info("RoomServiceFactory 초기화 완료. 등록된 서비스: {}", 
+                    serviceMap.keySet().stream()
+                            .map(type -> type.getDisplayName())
+                            .collect(Collectors.joining(", ")));
+        }
+    }
+
+    /**
+     * 룸 타입에 해당하는 서비스를 반환합니다
+     * 
+     * @param roomType 룸 타입
+     * @return 해당 타입의 RoomService 구현체
+     * @throws IllegalArgumentException 지원하지 않는 룸 타입인 경우
+     */
+    public RoomService getService(RoomType roomType) {
+        if (roomType == null) {
+            throw new IllegalArgumentException("룸 타입이 null입니다");
+        }
+
+        initializeServiceMap();
+
+        RoomService service = serviceMap.get(roomType);
+        if (service == null) {
+            throw new IllegalArgumentException(
+                    String.format("지원하지 않는 룸 타입입니다: %s. 지원 가능한 타입: %s", 
+                            roomType.getDisplayName(),
+                            serviceMap.keySet().stream()
+                                    .map(RoomType::getDisplayName)
+                                    .collect(Collectors.joining(", "))
+                    )
+            );
+        }
+
+        log.debug("RoomService 반환: {} -> {}", 
+                roomType.getDisplayName(), 
+                service.getClass().getSimpleName());
+        
+        return service;
+    }
+
+    /**
+     * 룸 타입 코드로 서비스를 반환합니다
+     * 
+     * @param roomTypeCode 룸 타입 코드 ("ai", "chat")
+     * @return 해당 타입의 RoomService 구현체
+     */
+    public RoomService getService(String roomTypeCode) {
+        RoomType roomType = RoomType.fromCode(roomTypeCode);
+        return getService(roomType);
+    }
+
+    /**
+     * 등록된 모든 룸 서비스 목록을 반환합니다
+     * 
+     * @return 등록된 RoomService 목록
+     */
+    public List<RoomService> getAllServices() {
+        return List.copyOf(roomServices);
+    }
+
+    /**
+     * 지원하는 모든 룸 타입을 반환합니다
+     * 
+     * @return 지원하는 RoomType 목록
+     */
+    public List<RoomType> getSupportedRoomTypes() {
+        initializeServiceMap();
+        return List.copyOf(serviceMap.keySet());
+    }
+
+    /**
+     * 특정 룸 타입이 지원되는지 확인합니다
+     * 
+     * @param roomType 확인할 룸 타입
+     * @return 지원 여부
+     */
+    public boolean isSupported(RoomType roomType) {
+        initializeServiceMap();
+        return serviceMap.containsKey(roomType);
+    }
+
+    /**
+     * 특정 룸 타입 코드가 지원되는지 확인합니다
+     * 
+     * @param roomTypeCode 확인할 룸 타입 코드
+     * @return 지원 여부
+     */
+    public boolean isSupported(String roomTypeCode) {
+        try {
+            RoomType roomType = RoomType.fromCode(roomTypeCode);
+            return isSupported(roomType);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * 팩토리 상태 정보를 반환합니다 (디버깅/모니터링 용)
+     * 
+     * @return 팩토리 상태 정보
+     */
+    public String getFactoryStatus() {
+        initializeServiceMap();
+        
+        StringBuilder status = new StringBuilder();
+        status.append("RoomServiceFactory Status:\n");
+        status.append("- 등록된 서비스 수: ").append(serviceMap.size()).append("\n");
+        
+        serviceMap.forEach((type, service) -> {
+            status.append("- ").append(type.getDisplayName())
+                  .append(" (").append(type.getCode()).append(")")
+                  .append(" -> ").append(service.getClass().getSimpleName())
+                  .append("\n");
+        });
+        
+        return status.toString();
+    }
+}

--- a/src/main/resources/static/dungeon-game.html
+++ b/src/main/resources/static/dungeon-game.html
@@ -1159,13 +1159,14 @@
             
             // WebSocket으로 전송
             if (aiStompClient && aiStompClient.connected) {
-                aiStompClient.send('/pub/aichat/send', {}, JSON.stringify({
-                    aiGameRoomId: aiGameRoomId,
-                    gameId: currentGameSession.gameSessionId,
+                aiStompClient.send('/pub/room/ai/send', {}, JSON.stringify({
+                    roomId: aiGameRoomId,
+                    roomType: 'AI_GAME',
                     senderId: currentUser.id,
-                    senderNickname: currentUser.name, // nickname 대신 name 사용
-                    content: message,
                     messageType: 'USER',
+                    content: message,
+                    aiGameRoomId: aiGameRoomId,
+                    gameActionType: 'CHAT',
                     turnNumber: getCurrentTurnNumber()
                 }));
             }
@@ -1223,12 +1224,14 @@
             
             // WebSocket으로 전송
             if (partyStompClient && partyStompClient.connected) {
-                partyStompClient.send('/pub/chat/send', {}, JSON.stringify({
+                partyStompClient.send('/pub/room/chat/send', {}, JSON.stringify({
                     roomId: partyRoomId,
+                    roomType: 'PLAYER_CHAT',
                     senderId: currentUser.id,
-                    senderNickname: currentUser.name, // nickname 대신 name 사용
+                    messageType: 'USER',
                     content: message,
-                    type: 'TALK'
+                    chatRoomId: partyRoomId,
+                    senderNickname: currentUser.name
                 }));
             }
             


### PR DESCRIPTION
 Refactor: AI 채팅, 매칭, 실시간 채팅 시스템 통합 및 아키텍처 개선

  PR 내용

  주요 변경 사항

  이번 Pull Request는 기존 시스템을 대대적으로 리팩토링하고, 여러 핵심 기능을
  새롭게 통합하여 전체적인 백엔드 아키텍처를 개선하는 데 중점을 두었습니다.

   1. AI 채팅 시스템 (`aichat`) 신규 구현
       * AI와 상호작용하며 진행하는 게임방의 생성, 상태 관리, 메시징 등 전체
         플로우를 구현했습니다.
       * Python AI 서비스와 RESTful API로 연동하여 동적인 AI 응답을 생성하고
         처리합니다.
       * WebSocket(STOMP)을 통해 실시간으로 AI의 응답과 게임 상태를 클라이언트에
         전달합니다.

   2. 실시간 매칭 시스템 (`matching`) 신규 구현
       * Redis의 List와 Hash 자료구조를 활용하여 세계관(FANTASY, SF, MODERN)
         기반의 3인 파티 매칭 시스템을 구축했습니다.
       * 매칭 대기열, 사용자 상태, 매칭 완료 세션 정보를 Redis에서 효율적으로
         관리합니다.
       * WebSocket을 통해 매칭 대기열 상태와 매칭 완료 이벤트를 실시간으로
         클라이언트에 알립니다.

   3. 실시간 채팅 시스템 (`chat`) 신규 구현
       * 플레이어 간의 일반 채팅 기능을 위한 WebSocket(STOMP) 및 Redis Pub/Sub
         기반의 실시간 채팅 시스템을 구현했습니다.
       * 채팅방 참여/퇴장 시 실시간으로 접속자 수를 브로드캐스팅합니다.

   4. 코어 아키텍처 리팩토링 및 개선
       * 인증 시스템: JWT 기반의 인증/인가 시스템을 도입하고, Refresh Token을
         Valkey(Redis)에 저장하여 세션을 관리합니다.
       * 통합 룸 서비스: RoomServiceFactory와 어댑터 패턴을 도입하여 AI 게임방과
         일반 채팅방을 일관된 인터페이스로 관리할 수 있도록 추상화했습니다.
       * DDD 패키지 구조: "Package by Feature" 원칙에 따라 aichat, matching, chat,
          auth 등 도메인별로 패키지 구조를 명확하게 분리하여 응집도를 높이고
         결합도를 낮췄습니다.
       * 공통 모듈: 전역 예외 처리, CORS, HTTP Client, WebSocket, 보안 설정 등
         공통 로직을 global 패키지로 분리하여 재사용성을 높였습니다.

   5. 문서화 및 테스트 환경 구축
       * docs/에 aichat, matching 시스템의 아키텍처, API 가이드, 리팩토링 가이드
         등 상세한 문서를 추가했습니다.
       * 프론트엔드 테스트를 위한 dungeon-game.html, chat-ssr-test.html 등 여러
         정적 테스트 페이지를 추가했습니다.

-- PR 시 다음과 같이 작성 
#31 

close #31 

  TODO

   - [ ] 최종 결과물을 확인했는가?
   - [ ] 의미 있는 커밋 메시지를 작성했는가?
     - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
     - 나쁜 예시) feat: 로그인 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 통합 룸 시스템 도입: 단일 REST/STOMP 엔드포인트로 AI 게임룸·플레이어 채팅룸 생성/조회/참여/퇴장/메시지 전송 지원.
  - 통합 메시지/룸 타입·상태 도입으로 일관된 표시와 참여 가능 여부 제공.
  - 매칭 완료 시 AI·채팅 룸을 일괄 생성하고 각각의 ID를 반환.

- Refactor
  - 웹소켓 발행 경로를 /pub/room/{roomType}/… 형태로 표준화하고 메시지 페이로드를 통합 스키마로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->