### PR TITLE
[Setting] LocalDateTime -> Instant형식으로 저장 & Instant 객체 반환 시, 자동으로 KST 시간대 적용 설정 

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/controller/ValkeyController.java
@@ -6,8 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,17 +20,16 @@ public class ValkeyController {
     // 테스트용 세션 데이터 저장 (Key, Value 입력)
     @GetMapping("/session/test/save")
     public String saveTestSessionData() {
-        String key = "test-key" + LocalDateTime.now();
-        String value = LocalDateTime.now().toString();
+        String key = "test-key" + Instant.now().toString();
+        String value = Instant.now().toString();
         valkeyService.saveSessionData(key, value);
         return "Saved test session data: " + key + " = " + value;
     }
 
     // 현재 우리 세션 valkey에 등록된 유저들의 토큰을 모두 조회하는 컨트롤러
     @GetMapping("/session/all")
-    public Map<String, String> getAllSessionData() {
+    public Map<String, Instant> getAllSessionData() {
 
-        //return valkeyService.getAllTestKeySessionData();
         return valkeyService.getAllSessionKeyValues();
     }
 

--- a/src/main/java/org/com/dungeontalk/domain/auth/entity/Auth.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/entity/Auth.java
@@ -1,14 +1,13 @@
 package org.com.dungeontalk.domain.auth.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.com.dungeontalk.domain.member.entity.Member;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "auth")
@@ -19,12 +18,6 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class Auth extends BaseEntity {
 
-//    @EmbeddedId
-//    private AuthId authId;
-    // ManyToOne으로 member 참조 (member_id 필드와 연동)
-    //@MapsId("memberId") // AuthId.memberId와 매핑
-
-    //@JoinColumn(name = "member_id", insertable = false, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")  // insertable/updatable 옵션 제거
     private Member member;
@@ -41,12 +34,4 @@ public class Auth extends BaseEntity {
 
     @Column(name = "refresh_token", columnDefinition = "text")
     private String refreshToken;
-
-//    @CreationTimestamp
-//    @Column(name = "created_at", updatable = false)
-//    private LocalDateTime createdAt;
-//
-//    @UpdateTimestamp
-//    @Column(name = "updated_at")
-//    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/ValkeyService.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -31,35 +33,46 @@ public class ValkeyService {
         sessionRedis.opsForValue().set(key, value);
     }
 
-    public Map<String, String> getAllSessionKeyValues() {
-        Set<String> keys = sessionRedis.keys("*");  // 모든 키 조회
-        Map<String, String> result = new HashMap<>();
+    // 모든 키-값 조회
+    public Map<String, Instant> getAllSessionKeyValues() {
+        Set<String> keys = sessionRedis.keys("*");
+        Map<String, Instant> result = new HashMap<>();
 
         if (keys != null && !keys.isEmpty()) {
             for (String key : keys) {
-                String value = sessionRedis.opsForValue().get(key);  // String 타입 값 조회
-                result.put(key, value);
+                String valueStr = sessionRedis.opsForValue().get(key);
+                if (valueStr != null) {
+                    try {
+                        Instant value = Instant.parse(valueStr);
+                        result.put(key, value);
+                    } catch (DateTimeParseException e) {
+                        // 파싱 불가능한 값은 무시하거나 로그 처리
+                        System.out.println("Invalid Instant format for key: " + key + ", value: " + valueStr);
+                    }
+                }
             }
         }
-
         return result;
     }
 
-    // Redis 세션에 저장된 test키 모두 조회
-    public Map<String, String> getAllTestKeySessionData() {
-        String pattern = "test-key*";  // test-key로 시작하는 모든 키 조회
-        Set<String> keys = sessionRedis.keys(pattern);
-        Map<String, String> result = new HashMap<>();
-
-        if (keys != null) {
-            for (String key : keys) {
-                String value = sessionRedis.opsForValue().get(key);  // String 타입 값 조회
-                result.put(key, value);
-            }
-        }
-
-        return result;
-    }
+    /* DEPRECATED CODE */
+//    public Map<String, String> getAllSessionKeyValues() {
+//        Set<String> keys = sessionRedis.keys("*");  // 모든 키 조회
+//        Map<String, String> result = new HashMap<>();
+//
+//        if (keys != null && !keys.isEmpty()) {
+//            for (String key : keys) {
+//                String  valueStr  = sessionRedis.opsForValue().get(key);  // String 타입 값 조회
+//                if ( valueStr  != null) {
+//                    Instant value = Instant.parse( valueStr );  // String -> Instant 변환
+//                    result.put(key, value);
+//                }
+//                // result.put(key, value);
+//            }
+//        }
+//
+//        return result;
+//    }
 
 
     public Set<String> getAllSessionKeys() {

--- a/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/entity/Member.java
@@ -1,13 +1,13 @@
 package org.com.dungeontalk.domain.member.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "member")
@@ -17,10 +17,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class Member extends BaseEntity {
 
-//    @Id
-//    @Column(name = "id", nullable = false)
-//    private String id;
-
     @Column(name = "password", nullable = false)
     private String password;
 
@@ -29,12 +25,4 @@ public class Member extends BaseEntity {
 
     @Column(name = "nick_name",  unique = true)
     private String nickName;
-
-//    @CreationTimestamp
-//    @Column(name = "created_at", updatable = false)
-//    private LocalDateTime createdAt;
-//
-//    @UpdateTimestamp
-//    @Column(name = "updated_at")
-//    private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
+++ b/src/main/java/org/com/dungeontalk/global/common/entity/BaseEntity.java
@@ -10,7 +10,8 @@ import org.com.dungeontalk.global.util.UuidV7Creator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import java.time.LocalDateTime;
+
+import java.time.Instant;
 
 @MappedSuperclass
 @Getter
@@ -28,10 +29,10 @@ public class BaseEntity {
     private String id;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     // UUID 자동 할당
     @PrePersist

--- a/src/main/java/org/com/dungeontalk/global/config/TimeZone/InstantToKstSerializer.java
+++ b/src/main/java/org/com/dungeontalk/global/config/TimeZone/InstantToKstSerializer.java
@@ -1,0 +1,27 @@
+package org.com.dungeontalk.global.config.TimeZone;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class InstantToKstSerializer extends StdSerializer<Instant> {
+
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                    .withZone(ZoneId.of("Asia/Seoul"));
+
+    public InstantToKstSerializer() {
+        super(Instant.class);
+    }
+
+    @Override
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        String formatted = FORMATTER.format(value);
+        gen.writeString(formatted);
+    }
+}

--- a/src/main/java/org/com/dungeontalk/global/config/TimeZone/JacksonConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/TimeZone/JacksonConfig.java
@@ -1,0 +1,32 @@
+package org.com.dungeontalk.global.config.TimeZone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+
+    private final ObjectMapper objectMapper;
+
+    public JacksonConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void setup() {
+        objectMapper.registerModule(new JavaTimeModule());
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Instant.class, new InstantToKstSerializer());
+        objectMapper.registerModule(module);
+
+        objectMapper.setTimeZone(TimeZone.getTimeZone(ZoneId.of("Asia/Seoul")));
+    }
+}


### PR DESCRIPTION
# 요약

이 PR은 Java `Instant` 타입을 JSON으로 직렬화할 때 기본 UTC 대신 한국 표준시(KST, Asia/Seoul 시간대) 기준의 사람이 읽기 좋은 `yyyy-MM-dd HH:mm:ss` 형식 문자열로 변환해 반환하도록 Jackson 커스텀 직렬화기를 적용하는 기능을 추가합니다.
이를 통해 API 응답에서 Instant 타입의 시간이 자동으로 KST 시간대로 변환되어 사용자에게 제공됩니다.

# 연관 이슈 및 Close 할 이슈 작성

setting #33 

# Pull Request 체크리스트

## TODO
- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
  * 좋은 예시) feat: Jackson Instant → KST 변환 커스텀 직렬화기 적용 (#123)
  * 나쁜 예시) feat: 시간 변환 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 전역 시간 처리 설정 추가: 모든 시간 값을 KST(Asia/Seoul) 기준 “yyyy-MM-dd HH:mm:ss” 형식으로 직렬화하여 응답합니다.
- 리팩터
  - 애플리케이션 전반의 시간 타입을 Instant로 통일해 일관성과 정확성을 개선했습니다.
  - 세션 데이터 조회의 반환 값이 문자열에서 시간 타입 기반으로 변경되어 시간 정보가 더 명확해졌습니다.
  - 인증/회원 엔티티 구조를 단순화하고 빌더/접근자 생성으로 객체 생성과 사용 편의성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->