### PR TITLE
refactor(aichat): DTO 클래스 구조 개선 및 코드 정리

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequest.java
@@ -1,0 +1,35 @@
+package org.com.dungeontalk.domain.aichat.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Jacksonized
+public class AiServiceRequest {
+    @JsonProperty("game_id")
+    private String gameId;
+    
+    @JsonProperty("ai_game_room_id")
+    private String aiGameRoomId;
+    
+    @JsonProperty("current_user")
+    private String currentUser;
+    
+    @JsonProperty("current_message")
+    private String currentMessage;
+    
+    @JsonProperty("context_messages")
+    private List<ContextMessage> contextMessages;
+    
+    @JsonProperty("turn_number")
+    private int turnNumber;
+}

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/ContextMessage.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/ContextMessage.java
@@ -1,0 +1,14 @@
+package org.com.dungeontalk.domain.aichat.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContextMessage {
+    private String messageType;
+    private String senderNickname;
+    private String content;
+    private int turnNumber;
+    private int messageOrder;
+}

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiServiceResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiServiceResponse.java
@@ -1,0 +1,14 @@
+package org.com.dungeontalk.domain.aichat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AiServiceResponse {
+    private String content;
+    private Long responseTime;
+    private List<String> sources;
+}

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiApiService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiApiService.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
+import org.com.dungeontalk.domain.aichat.dto.request.AiServiceRequest;
+import org.com.dungeontalk.domain.aichat.dto.request.ContextMessage;
+import org.com.dungeontalk.domain.aichat.dto.response.AiServiceResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -33,7 +36,7 @@ public class AiApiService {
     /**
      * Python AI 서비스에서 응답 생성
      */
-    public AiResponseResult generateAiResponse(String gameId, String aiGameRoomId, 
+    public AiServiceResponse generateAiResponse(String gameId, String aiGameRoomId, 
                                              String currentUser, String currentMessage,
                                              List<AiGameMessageDto> contextMessages, int turnNumber) {
         
@@ -44,7 +47,7 @@ public class AiApiService {
                      aiGameRoomId, currentUser, turnNumber);
 
             // 요청 데이터 구성
-            AiResponseRequest request = AiResponseRequest.builder()
+            AiServiceRequest request = AiServiceRequest.builder()
                     .gameId(gameId)
                     .aiGameRoomId(aiGameRoomId)
                     .currentUser(currentUser)
@@ -59,7 +62,7 @@ public class AiApiService {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
 
-            HttpEntity<AiResponseRequest> httpEntity = new HttpEntity<>(request, headers);
+            HttpEntity<AiServiceRequest> httpEntity = new HttpEntity<>(request, headers);
 
             // Python AI 서비스 호출
             ResponseEntity<Map> response = restTemplate.exchange(
@@ -84,7 +87,7 @@ public class AiApiService {
                     responseTime = ((Number) responseBody.get("response_time")).longValue();
                 }
                 
-                AiResponseResult result = AiResponseResult.builder()
+                AiServiceResponse result = AiServiceResponse.builder()
                         .content(content)
                         .responseTime(responseTime)
                         .sources((List<String>) responseBody.get("sources"))
@@ -150,44 +153,4 @@ public class AiApiService {
                 .build();
     }
 
-    // Inner classes for request/response DTOs
-    @lombok.Builder
-    @lombok.Data
-    public static class AiResponseRequest {
-        @com.fasterxml.jackson.annotation.JsonProperty("game_id")
-        private String gameId;
-        
-        @com.fasterxml.jackson.annotation.JsonProperty("ai_game_room_id")
-        private String aiGameRoomId;
-        
-        @com.fasterxml.jackson.annotation.JsonProperty("current_user")
-        private String currentUser;
-        
-        @com.fasterxml.jackson.annotation.JsonProperty("current_message")
-        private String currentMessage;
-        
-        @com.fasterxml.jackson.annotation.JsonProperty("context_messages")
-        private List<ContextMessage> contextMessages;
-        
-        @com.fasterxml.jackson.annotation.JsonProperty("turn_number")
-        private int turnNumber;
-    }
-
-    @lombok.Builder
-    @lombok.Data
-    public static class ContextMessage {
-        private String messageType;
-        private String senderNickname;
-        private String content;
-        private int turnNumber;
-        private int messageOrder;
-    }
-
-    @lombok.Builder
-    @lombok.Data
-    public static class AiResponseResult {
-        private String content;
-        private Long responseTime;
-        private List<String> sources;
-    }
 }

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameFlowService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameFlowService.java
@@ -3,6 +3,7 @@ package org.com.dungeontalk.domain.aichat.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
+import org.com.dungeontalk.domain.aichat.dto.response.AiServiceResponse;
 import org.com.dungeontalk.domain.aichat.dto.request.AiErrorRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.AiGenerateRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.AiGameMessageSendRequest;
@@ -51,7 +52,7 @@ public class AiGameFlowService {
                     .getContextMessages(roomId, DEFAULT_CONTEXT_MESSAGE_COUNT, request.getTurnNumber());
 
             // Python AI 서비스에서 응답 생성
-            AiApiService.AiResponseResult aiResult = aiApiService.generateAiResponse(
+            AiServiceResponse aiResult = aiApiService.generateAiResponse(
                     request.getGameId(),
                     roomId,
                     request.getCurrentUser(),


### PR DESCRIPTION

# 요약
- AiApiService 내부 static 클래스들을 별도 파일로 분리
- AiServiceRequest, ContextMessage, AiServiceResponse DTO 생성
- @Data 대신 @Getter + @Builder 사용으로 불변성 보장
- Lombok 어노테이션 import 방식으로 변경
- Chat 도메인 컨벤션에 맞춰 @Jacksonized 적용

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#48 

close #48 

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - AI 채팅 응답에 콘텐츠 외에 응답 시간과 출처 목록을 함께 제공하여 후속 표시·기록이 가능해졌습니다.
- 리팩터링
  - AI 채팅 요청·응답 데이터 포맷을 통일하고 서비스 간 연동을 단순화했습니다.
  - 내부 중복 구조를 제거하고, 요청 필드(게임/방/사용자/메시지/문맥/턴)를 표준화했습니다.
  - 상위 흐름 서비스가 새로운 응답 타입을 사용하도록 정리되어 처리 경로가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->