### PR TITLE
[TEST]  AiServiceRequest, AiGameMessageRepository, AiGameMessageService 테스트 코드 추가

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/AiGameMessageDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/AiGameMessageDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import org.com.dungeontalk.domain.aichat.common.AiMessageType;
 import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -24,7 +24,7 @@ public class AiGameMessageDto {
     private AiMessageType messageType;
     private int turnNumber;
     private int messageOrder;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     /**
      * Entity를 DTO로 변환

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/AiGameRoomDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/AiGameRoomDto.java
@@ -8,7 +8,7 @@ import org.com.dungeontalk.domain.aichat.common.AiGamePhase;
 import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
 import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -26,7 +26,7 @@ public class AiGameRoomDto {
     private int maxParticipants;
     private List<String> participants;
     private String gameSettings;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     /**
      * Entity를 DTO로 변환

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameMessageResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameMessageResponse.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import org.com.dungeontalk.domain.aichat.common.AiMessageType;
 import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Builder
@@ -23,7 +23,7 @@ public class AiGameMessageResponse {
     private AiMessageType messageType;
     private int turnNumber;
     private int messageOrder;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     /**
      * AI 메시지 여부

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameRoomResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameRoomResponse.java
@@ -9,7 +9,7 @@ import org.com.dungeontalk.domain.aichat.common.AiGamePhase;
 import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
 import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +52,7 @@ public class AiGameRoomResponse {
     private List<String> participants;
     
     @Schema(description = "생성 시간")
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     /**
      * 입장 가능 여부

--- a/src/main/java/org/com/dungeontalk/domain/aichat/entity/AiGameMessage.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/entity/AiGameMessage.java
@@ -6,7 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * AI 게임 메시지를 저장하는 MongoDB 문서 엔티티
@@ -32,7 +32,7 @@ public class AiGameMessage {
     private int messageOrder; //메시지 순서 (같은 턴 내에서의 순서)
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     /**
      * AI 메시지인지 확인

--- a/src/main/java/org/com/dungeontalk/domain/aichat/entity/AiGameRoom.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/entity/AiGameRoom.java
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import jakarta.persistence.EntityListeners;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class AiGameRoom {
     private List<String> participants = new ArrayList<>();
     private String gameSettings; // 게임 설정 (TRPG 세계관, 난이도 등 - JSON 형태 저장 가능)
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     // 마지막 활동 시간 (플레이어 입력 또는 AI 응답 시간)
     public boolean isActive() {

--- a/src/main/java/org/com/dungeontalk/domain/aichat/repository/AiGameRoomRepository.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/repository/AiGameRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageService.java
@@ -36,7 +36,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -352,7 +352,7 @@ public class AiGameMessageService {
                 .messageType(AiMessageType.USER)
                 .turnNumber(request.getTurnNumber())
                 .messageOrder(nextMessageOrder)
-                .createdAt(LocalDateTime.now())
+                .createdAt(Instant.now())
                 .build();
 
         AiGameMessage saved = aiGameMessageRepository.save(message);
@@ -396,7 +396,7 @@ public class AiGameMessageService {
                 .messageType(AiMessageType.AI)
                 .turnNumber(request.getTurnNumber())
                 .messageOrder(nextMessageOrder)
-                .createdAt(LocalDateTime.now())
+                .createdAt(Instant.now())
                 .build();
 
         AiGameMessage saved = aiGameMessageRepository.save(message);
@@ -455,7 +455,7 @@ public class AiGameMessageService {
                 .messageType(AiMessageType.SYSTEM)
                 .turnNumber(request.getTurnNumber())
                 .messageOrder(request.getMessageOrder())
-                .createdAt(LocalDateTime.now())
+                .createdAt(Instant.now())
                 .build();
 
         AiGameMessage saved = aiGameMessageRepository.save(message);
@@ -484,7 +484,7 @@ public class AiGameMessageService {
                 .messageType(AiMessageType.TURN_START)
                 .turnNumber(request.getTurnNumber())
                 .messageOrder(AiChatConfigHelper.getTurnStartMessageOrder())
-                .createdAt(LocalDateTime.now())
+                .createdAt(Instant.now())
                 .build();
 
         AiGameMessage saved = aiGameMessageRepository.save(message);
@@ -513,7 +513,7 @@ public class AiGameMessageService {
                 .messageType(AiMessageType.TURN_END)
                 .turnNumber(request.getTurnNumber())
                 .messageOrder(AiChatConfigHelper.getTurnEndMessageOrder())
-                .createdAt(LocalDateTime.now())
+                .createdAt(Instant.now())
                 .build();
 
         AiGameMessage saved = aiGameMessageRepository.save(message);

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameRoomService.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameStateService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiGameStateService.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.com.dungeontalk.domain.aichat.common.AiChatConstants.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 

--- a/src/test/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequestTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequestTest.java
@@ -1,0 +1,101 @@
+package org.com.dungeontalk.domain.aichat.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class AiServiceRequestTest {
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    
+    @Test
+    @DisplayName("Builder로 객체 생성 테스트")
+    void builderCreatesObject() {
+        // given
+        String gameId = "test-game-123";
+        String aiGameRoomId = "test-room-456";
+        String currentUser = "user-789";
+        String currentMessage = "안녕하세요!";
+        int turnNumber = 5;
+        
+        // when
+        AiServiceRequest result = AiServiceRequest.builder()
+                .gameId(gameId)
+                .aiGameRoomId(aiGameRoomId)
+                .currentUser(currentUser)
+                .currentMessage(currentMessage)
+                .turnNumber(turnNumber)
+                .build();
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getGameId()).isEqualTo(gameId);
+        assertThat(result.getAiGameRoomId()).isEqualTo(aiGameRoomId);
+        assertThat(result.getCurrentUser()).isEqualTo(currentUser);
+        assertThat(result.getCurrentMessage()).isEqualTo(currentMessage);
+        assertThat(result.getTurnNumber()).isEqualTo(turnNumber);
+    }
+
+    //실행되면 파이썬에서도 실행 가능함 왜 이 dto를 실행하느냐 하면  파이썬에서는 카멜 케이스가 아니라 스네이크로 받는데 dto 단에서 오류가
+    // 발생할수도 있어서 현재 이렇게 했습니다.
+    @Test
+    @DisplayName("Java 객체를 JSON으로 변환 (@JsonProperty 매핑 확인)")
+    void serializeToJson() throws Exception {
+        // given
+        AiServiceRequest request = AiServiceRequest.builder()
+                .gameId("game-123")
+                .aiGameRoomId("room-456")
+                .currentUser("user-789")
+                .currentMessage("테스트 메시지")
+                .turnNumber(3)
+                .contextMessages(List.of())
+                .build();
+        
+        // when
+        String json = objectMapper.writeValueAsString(request);
+        
+        // then - @JsonProperty로 설정한 snake_case 키들이 있는지 확인
+        assertThat(json).contains("\"game_id\":\"game-123\"");
+        assertThat(json).contains("\"ai_game_room_id\":\"room-456\"");
+        assertThat(json).contains("\"current_user\":\"user-789\"");
+        assertThat(json).contains("\"current_message\":\"테스트 메시지\"");
+        assertThat(json).contains("\"turn_number\":3");
+        assertThat(json).contains("\"context_messages\":[]");
+        
+        // camelCase가 아닌지도 확인 (혹시 @JsonProperty가 안 되었을 경우)
+        assertThat(json).doesNotContain("gameId");
+        assertThat(json).doesNotContain("aiGameRoomId");
+    }
+    
+    @Test
+    @DisplayName("JSON을 Java 객체로 변환 (snake_case → camelCase)")
+    void deserializeFromJson() throws Exception {
+        // given - Python AI 서비스에서 보낼 수 있는 JSON 형태
+        String json = """
+            {
+                "game_id": "test-game",
+                "ai_game_room_id": "test-room", 
+                "current_user": "test-user",
+                "current_message": "안녕하세요",
+                "turn_number": 7,
+                "context_messages": []
+            }
+            """;
+        
+        // when
+        AiServiceRequest result = objectMapper.readValue(json, AiServiceRequest.class);
+        
+        // then - @JsonProperty 매핑으로 올바르게 변환되었는지 확인
+        assertThat(result).isNotNull();
+        assertThat(result.getGameId()).isEqualTo("test-game");
+        assertThat(result.getAiGameRoomId()).isEqualTo("test-room");
+        assertThat(result.getCurrentUser()).isEqualTo("test-user");
+        assertThat(result.getCurrentMessage()).isEqualTo("안녕하세요");
+        assertThat(result.getTurnNumber()).isEqualTo(7);
+        assertThat(result.getContextMessages()).isNotNull().isEmpty();
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameMessageRepositoryTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameMessageRepositoryTest.java
@@ -1,0 +1,95 @@
+package org.com.dungeontalk.domain.aichat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
+import org.com.dungeontalk.domain.aichat.common.AiMessageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers        // Docker 컨테이너 자동 관리
+@DataMongoTest         // MongoDB Repository 테스트 전용
+@ActiveProfiles("test") // 테스트 설정 사용
+class AiGameMessageRepositoryTest {
+
+    // MongoDB 컨테이너 설정 (Chat과 동일)
+    @Container
+    static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0");
+
+    // 컨테이너 URI를 Spring에 주입
+    @DynamicPropertySource
+    static void mongoProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private AiGameMessageRepository repository;
+
+    // 테스트 후 데이터 정리 (다른 테스트에 영향 안 주려고)
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll();
+    }
+
+    // 테스트용 메시지 생성 헬퍼 메서드
+    private AiGameMessage createTestMessage(String roomId, String content, int turnNumber, Instant when) {
+        return AiGameMessage.builder()
+                .id(UUID.randomUUID().toString())
+                .aiGameRoomId(roomId)
+                .content(content)
+                .messageType(AiMessageType.USER)
+                .senderNickname("테스터")
+                .turnNumber(turnNumber)
+                .messageOrder(1)
+                .createdAt(when)
+                .build();
+    }
+
+    @Test
+    @DisplayName("메시지 저장 및 조회 기본 테스트")
+    void saveAndFind() {
+        // given
+        AiGameMessage message = createTestMessage("room-1", "안녕하세요", 1, Instant.now());
+
+        // when
+        AiGameMessage saved = repository.save(message);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(repository.findById(saved.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("같은 방의 메시지들만 조회되는지 확인")
+    void findMessagesByRoom() {
+        // given - 두 개의 다른 방에 메시지 저장
+        AiGameMessage room1Message = createTestMessage("room-1", "첫 번째 방 메시지", 1, Instant.now());
+        AiGameMessage room2Message = createTestMessage("room-2", "두 번째 방 메시지", 1, Instant.now());
+        
+        repository.save(room1Message);
+        repository.save(room2Message);
+        
+        // when - room-1의 메시지만 조회
+        PageRequest pageRequest = PageRequest.of(0, 10); // 최대 10개까지
+        List<AiGameMessage> result = repository.findByAiGameRoomIdOrderByCreatedAtDesc("room-1", pageRequest);
+        
+        // then - room-1 메시지만 나와야 함
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getContent()).isEqualTo("첫 번째 방 메시지");
+        assertThat(result.get(0).getAiGameRoomId()).isEqualTo("room-1");
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageServiceTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageServiceTest.java
@@ -1,0 +1,153 @@
+package org.com.dungeontalk.domain.aichat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.com.dungeontalk.domain.aichat.common.AiMessageType;
+import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
+import org.com.dungeontalk.domain.aichat.dto.request.AiMessageSaveRequest;
+import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
+import org.com.dungeontalk.domain.aichat.repository.AiGameMessageRepository;
+import org.com.dungeontalk.domain.aichat.repository.AiGameRoomRepository;
+import org.com.dungeontalk.domain.aichat.util.AiGameValidator;
+import org.com.dungeontalk.domain.aichat.service.AiGameRoomService;
+import org.com.dungeontalk.domain.aichat.service.AiGameStateService;
+import org.com.dungeontalk.global.filter.ProfanityFilterService;
+import org.com.dungeontalk.global.filter.config.ProfanityFilterProperties;
+import org.com.dungeontalk.global.redis.RedisPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class AiGameMessageServiceTest {
+
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+    
+    @Mock
+    AiGameMessageRepository aiGameMessageRepository;
+    
+    @Mock
+    AiGameRoomRepository aiGameRoomRepository;
+    
+    @Mock
+    AiGameValidator aiGameValidator;
+    
+    @Mock
+    RedisPublisher redisPublisher;
+    
+    @Mock
+    ObjectMapper objectMapper;
+    
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+    
+    @Mock
+    AiGameRoomService aiGameRoomService;
+    
+    @Mock
+    AiGameStateService aiGameStateService;
+    
+    @Mock
+    ProfanityFilterService profanityFilterService;
+    
+    @Mock
+    ProfanityFilterProperties profanityFilterProperties;
+
+    @InjectMocks
+    AiGameMessageService aiGameMessageService;
+
+    @Test
+    @DisplayName("AI 메시지 저장 성공 테스트")
+    void saveAiMessage_success() {
+        // given
+        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .content("AI 응답 메시지")
+                .turnNumber(1)
+                .build();
+        
+        // Mock: getNextMessageOrder 결과
+        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
+                .willReturn(Collections.emptyList());
+        
+        // Mock: 저장된 메시지 반환
+        AiGameMessage savedMessage = AiGameMessage.builder()
+                .id("saved-id")
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .senderId("AI_GM")
+                .senderNickname("던전 마스터")
+                .content("AI 응답 메시지")
+                .messageType(AiMessageType.AI)
+                .turnNumber(1)
+                .messageOrder(1)
+                .createdAt(Instant.now())
+                .build();
+        
+        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
+                .willReturn(savedMessage);
+        
+        // when
+        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEqualTo("AI 응답 메시지");
+        assertThat(result.getMessageType()).isEqualTo(AiMessageType.AI);
+        assertThat(result.getTurnNumber()).isEqualTo(1);
+        
+        // Mock 호출 검증
+        then(aiGameValidator).should().validateGameRoom("room-123");
+        then(aiGameMessageRepository).should().save(any(AiGameMessage.class));
+    }
+
+    @Test
+    @DisplayName("메시지 순서 계산 테스트")
+    void messageOrder_test() {
+        // given - 첫 번째 메시지인 경우
+        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .content("첫 번째 메시지")
+                .turnNumber(1)
+                .build();
+        
+        // Mock: 기존 메시지가 없는 경우
+        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
+                .willReturn(Collections.emptyList());
+        
+        AiGameMessage savedMessage = AiGameMessage.builder()
+                .id("saved-id")
+                .aiGameRoomId("room-123")
+                .messageOrder(1) // 첫 번째 메시지이므로 1
+                .turnNumber(1)
+                .content("첫 번째 메시지")
+                .messageType(AiMessageType.AI)
+                .createdAt(Instant.now())
+                .build();
+        
+        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
+                .willReturn(savedMessage);
+        
+        // when
+        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
+        
+        // then
+        assertThat(result.getMessageOrder()).isEqualTo(1);
+        then(aiGameMessageRepository).should().findMaxMessageOrderByTurn("room-123", 1);
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/matching/dto/request/MatchingJoinRequestTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/matching/dto/request/MatchingJoinRequestTest.java
@@ -1,0 +1,69 @@
+package org.com.dungeontalk.domain.matching.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.com.dungeontalk.domain.matching.common.WorldType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MatchingJoinRequestTest {
+    
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Builder로 객체 생성 테스트")
+    void builderCreatesObject() {
+        // given
+        String memberId = "user-12345";
+        WorldType worldType = WorldType.FANTASY;
+        
+        // when
+        MatchingJoinRequest result = MatchingJoinRequest.builder()
+                .memberId(memberId)
+                .worldType(worldType)
+                .build();
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo(memberId);
+        assertThat(result.getWorldType()).isEqualTo(worldType);
+    }
+
+    @Test
+    @DisplayName("Java 객체를 JSON으로 변환")
+    void serializeToJson() throws Exception {
+        // given
+        MatchingJoinRequest request = MatchingJoinRequest.builder()
+                .memberId("test-user")
+                .worldType(WorldType.FANTASY)
+                .build();
+        
+        // when
+        String json = objectMapper.writeValueAsString(request);
+        
+        // then
+        assertThat(json).contains("\"memberId\":\"test-user\"");
+        assertThat(json).contains("\"worldType\":\"FANTASY\"");
+    }
+
+    @Test
+    @DisplayName("JSON을 Java 객체로 변환")
+    void deserializeFromJson() throws Exception {
+        // given
+        String json = """
+            {
+                "memberId": "test-user",
+                "worldType": "FANTASY"
+            }
+            """;
+        
+        // when
+        MatchingJoinRequest result = objectMapper.readValue(json, MatchingJoinRequest.class);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo("test-user");
+        assertThat(result.getWorldType()).isEqualTo(WorldType.FANTASY);
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/matching/service/MatchingQueueManagerTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/matching/service/MatchingQueueManagerTest.java
@@ -1,0 +1,219 @@
+package org.com.dungeontalk.domain.matching.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.com.dungeontalk.domain.matching.common.MatchingConstants;
+import org.com.dungeontalk.domain.matching.common.WorldType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingQueueManagerTest {
+
+    @Mock
+    StringRedisTemplate redisTemplate;
+    
+    @Mock
+    ListOperations<String, String> listOperations;
+    
+    @Mock
+    HashOperations<String, Object, Object> hashOperations;
+    
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    MatchingQueueManager queueManager;
+
+    @Test
+    @DisplayName("사용자가 큐에 없는 경우 false 반환")
+    void isUserInQueue_false() {
+        // given
+        String memberId = "user-123";
+        String userKey = MatchingConstants.USER_KEY_PREFIX + memberId;
+        
+        given(redisTemplate.hasKey(userKey)).willReturn(false);
+        
+        // when
+        boolean result = queueManager.isUserInQueue(memberId);
+        
+        // then
+        assertThat(result).isFalse();
+        then(redisTemplate).should().hasKey(userKey);
+    }
+
+    @Test
+    @DisplayName("사용자가 큐에 있는 경우 true 반환")
+    void isUserInQueue_true() {
+        // given
+        String memberId = "user-123";
+        String userKey = MatchingConstants.USER_KEY_PREFIX + memberId;
+        
+        given(redisTemplate.hasKey(userKey)).willReturn(true);
+        
+        // when
+        boolean result = queueManager.isUserInQueue(memberId);
+        
+        // then
+        assertThat(result).isTrue();
+        then(redisTemplate).should().hasKey(userKey);
+    }
+
+    @Test
+    @DisplayName("큐에 사용자 추가 성공 테스트")
+    void addToQueue_success() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        String queueKey = worldType.getQueueKey();
+        String userKey = MatchingConstants.USER_KEY_PREFIX + memberId;
+        
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(redisTemplate.opsForHash()).willReturn(hashOperations);
+        given(listOperations.size(queueKey)).willReturn(5L); // 현재 큐 크기
+        
+        // when
+        queueManager.addToQueue(memberId, worldType);
+        
+        // then
+        then(listOperations).should().leftPush(queueKey, memberId);
+        then(hashOperations).should().putAll(eq(userKey), anyMap());
+        then(redisTemplate).should().expire(eq(userKey), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("큐에서 사용자 제거 성공 테스트")
+    void removeFromQueue_success() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        String userKey = MatchingConstants.USER_KEY_PREFIX + memberId;
+        String queueKey = worldType.getQueueKey();
+        
+        Map<Object, Object> userInfo = new HashMap<>();
+        userInfo.put("worldType", worldType.name());
+        userInfo.put("status", "WAITING");
+        
+        given(redisTemplate.opsForHash()).willReturn(hashOperations);
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(hashOperations.entries(userKey)).willReturn(userInfo);
+        given(listOperations.remove(queueKey, 0, memberId)).willReturn(1L);
+        
+        // when
+        boolean result = queueManager.removeFromQueue(memberId);
+        
+        // then
+        assertThat(result).isTrue();
+        then(listOperations).should().remove(queueKey, 0, memberId);
+        then(redisTemplate).should().delete(userKey);
+    }
+
+    @Test
+    @DisplayName("큐에서 사용자 제거 실패 테스트 - 사용자 정보 없음")
+    void removeFromQueue_failure_noUserInfo() {
+        // given
+        String memberId = "user-123";
+        String userKey = MatchingConstants.USER_KEY_PREFIX + memberId;
+        
+        given(redisTemplate.opsForHash()).willReturn(hashOperations);
+        given(hashOperations.entries(userKey)).willReturn(new HashMap<>());
+        
+        // when
+        boolean result = queueManager.removeFromQueue(memberId);
+        
+        // then
+        assertThat(result).isFalse();
+        then(redisTemplate).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("큐 크기 조회 테스트")
+    void getQueueSize_test() {
+        // given
+        WorldType worldType = WorldType.FANTASY;
+        String queueKey = worldType.getQueueKey();
+        Long expectedSize = 10L;
+        
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(listOperations.size(queueKey)).willReturn(expectedSize);
+        
+        // when
+        int result = queueManager.getQueueSize(worldType);
+        
+        // then
+        assertThat(result).isEqualTo(10);
+        then(listOperations).should().size(queueKey);
+    }
+
+    @Test
+    @DisplayName("큐 크기 조회 테스트 - null 반환시 0")
+    void getQueueSize_null_returns_zero() {
+        // given
+        WorldType worldType = WorldType.FANTASY;
+        String queueKey = worldType.getQueueKey();
+        
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(listOperations.size(queueKey)).willReturn(null);
+        
+        // when
+        int result = queueManager.getQueueSize(worldType);
+        
+        // then
+        assertThat(result).isEqualTo(0);
+        then(listOperations).should().size(queueKey);
+    }
+
+    @Test
+    @DisplayName("매칭 가능 여부 확인 테스트 - 3명 이상인 경우")
+    void canProcessMatching_true() {
+        // given
+        WorldType worldType = WorldType.FANTASY;
+        String queueKey = worldType.getQueueKey();
+        
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(listOperations.size(queueKey)).willReturn(5L);
+        
+        // when
+        boolean result = queueManager.canProcessMatching(worldType);
+        
+        // then
+        assertThat(result).isTrue();
+        then(listOperations).should().size(queueKey);
+    }
+
+    @Test
+    @DisplayName("매칭 가능 여부 확인 테스트 - 3명 미만인 경우")
+    void canProcessMatching_false() {
+        // given
+        WorldType worldType = WorldType.FANTASY;
+        String queueKey = worldType.getQueueKey();
+        
+        given(redisTemplate.opsForList()).willReturn(listOperations);
+        given(listOperations.size(queueKey)).willReturn(2L);
+        
+        // when
+        boolean result = queueManager.canProcessMatching(worldType);
+        
+        // then
+        assertThat(result).isFalse();
+        then(listOperations).should().size(queueKey);
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/matching/service/MatchingServiceTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/matching/service/MatchingServiceTest.java
@@ -1,0 +1,181 @@
+package org.com.dungeontalk.domain.matching.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import org.com.dungeontalk.domain.aichat.service.AiGameRoomService;
+import org.com.dungeontalk.domain.chat.service.ChatRoomService;
+import org.com.dungeontalk.domain.room.service.RoomServiceFactory;
+import org.com.dungeontalk.domain.matching.common.MatchingStatus;
+import org.com.dungeontalk.domain.matching.common.WorldType;
+import org.com.dungeontalk.domain.matching.dto.response.MatchingStatusResponse;
+import org.com.dungeontalk.global.exception.customException.AiChatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class MatchingServiceTest {
+
+    @Mock
+    MatchingQueueManager queueManager;
+    
+    @Mock
+    AiGameRoomService aiGameRoomService;
+    
+    @Mock
+    ChatRoomService chatRoomService;
+    
+    @Mock
+    StringRedisTemplate redisTemplate;
+    
+    @Mock
+    MatchingWebSocketService webSocketService;
+    
+    @Mock
+    RoomServiceFactory roomServiceFactory;
+
+    @InjectMocks
+    MatchingService matchingService;
+
+    @Test
+    @DisplayName("매칭 참가 성공 테스트")
+    void joinMatching_success() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        
+        given(queueManager.isUserInQueue(memberId)).willReturn(false);
+        given(queueManager.getQueueSize(worldType)).willReturn(5);
+        given(queueManager.getUserQueuePosition(memberId, worldType)).willReturn(6);
+        given(queueManager.canProcessMatching(worldType)).willReturn(false);
+        
+        // when
+        MatchingStatusResponse result = matchingService.joinMatching(memberId, worldType);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo(memberId);
+        assertThat(result.getWorldType()).isEqualTo(worldType);
+        assertThat(result.getStatus()).isEqualTo(MatchingStatus.WAITING);
+        assertThat(result.getCurrentPosition()).isEqualTo(6);
+        assertThat(result.getTotalInQueue()).isEqualTo(5);
+        
+        then(queueManager).should().addToQueue(memberId, worldType);
+        then(queueManager).should().getQueueSize(worldType);
+        then(queueManager).should().getUserQueuePosition(memberId, worldType);
+    }
+
+    @Test
+    @DisplayName("매칭 참가 실패 - 이미 큐에 있는 사용자")
+    void joinMatching_failure_alreadyInQueue() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        
+        given(queueManager.isUserInQueue(memberId)).willReturn(true);
+        
+        // when & then
+        assertThatThrownBy(() -> matchingService.joinMatching(memberId, worldType))
+                .isInstanceOf(AiChatException.class);
+        
+        then(queueManager).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    @DisplayName("매칭 취소 성공 테스트")
+    void cancelMatching_success() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        
+        Map<Object, Object> userInfo = new HashMap<>();
+        userInfo.put("worldType", worldType.name());
+        userInfo.put("status", "WAITING");
+        
+        given(queueManager.getUserMatchingInfo(memberId)).willReturn(userInfo);
+        given(queueManager.removeFromQueue(memberId)).willReturn(true);
+        given(queueManager.getQueueSize(worldType)).willReturn(4);
+        
+        // when
+        boolean result = matchingService.cancelMatching(memberId);
+        
+        // then
+        assertThat(result).isTrue();
+        then(queueManager).should().removeFromQueue(memberId);
+        then(webSocketService).should().sendMatchingCancelled(memberId, worldType);
+    }
+
+    @Test
+    @DisplayName("매칭 취소 실패 - 사용자가 대기 중이 아님")
+    void cancelMatching_failure_notInQueue() {
+        // given
+        String memberId = "user-123";
+        
+        given(queueManager.getUserMatchingInfo(memberId)).willReturn(new HashMap<>());
+        given(queueManager.removeFromQueue(memberId)).willReturn(false);
+        
+        // when
+        boolean result = matchingService.cancelMatching(memberId);
+        
+        // then
+        assertThat(result).isFalse();
+        then(queueManager).should().removeFromQueue(memberId);
+    }
+
+    @Test
+    @DisplayName("매칭 상태 조회 성공 테스트")
+    void getMatchingStatus_success() {
+        // given
+        String memberId = "user-123";
+        WorldType worldType = WorldType.FANTASY;
+        MatchingStatus status = MatchingStatus.WAITING;
+        Instant joinedAt = Instant.now();
+        
+        Map<Object, Object> userInfo = new HashMap<>();
+        userInfo.put("worldType", worldType.name());
+        userInfo.put("status", status.name());
+        userInfo.put("joinedAt", joinedAt.toString());
+        
+        given(queueManager.getUserMatchingInfo(memberId)).willReturn(userInfo);
+        given(queueManager.getQueueSize(worldType)).willReturn(5);
+        given(queueManager.getUserQueuePosition(memberId, worldType)).willReturn(3);
+        
+        // when
+        MatchingStatusResponse result = matchingService.getMatchingStatus(memberId);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMemberId()).isEqualTo(memberId);
+        assertThat(result.getWorldType()).isEqualTo(worldType);
+        assertThat(result.getStatus()).isEqualTo(status);
+        assertThat(result.getCurrentPosition()).isEqualTo(3);
+        assertThat(result.getTotalInQueue()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("매칭 상태 조회 실패 - 사용자 정보 없음")
+    void getMatchingStatus_failure_noUserInfo() {
+        // given
+        String memberId = "user-123";
+        
+        given(queueManager.getUserMatchingInfo(memberId)).willReturn(new HashMap<>());
+        
+        // when & then
+        assertThatThrownBy(() -> matchingService.getMatchingStatus(memberId))
+                .isInstanceOf(AiChatException.class);
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/room/service/RoomServiceFactoryTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/room/service/RoomServiceFactoryTest.java
@@ -1,0 +1,71 @@
+package org.com.dungeontalk.domain.room.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import org.com.dungeontalk.domain.room.common.RoomType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class RoomServiceFactoryTest {
+
+    @Mock
+    RoomService aiRoomService;
+    
+    @Mock  
+    RoomService chatRoomService;
+
+    @Test
+    @DisplayName("AI 룸 서비스 조회 성공 테스트")
+    void getService_ai_success() {
+        // given
+        given(aiRoomService.getSupportedRoomType()).willReturn(RoomType.AI_GAME);
+        given(chatRoomService.getSupportedRoomType()).willReturn(RoomType.PLAYER_CHAT);
+        
+        List<RoomService> roomServices = List.of(aiRoomService, chatRoomService);
+        RoomServiceFactory factory = new RoomServiceFactory(roomServices);
+        
+        // when
+        RoomService result = factory.getService(RoomType.AI_GAME);
+        
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(aiRoomService);
+    }
+
+    @Test
+    @DisplayName("null 입력시 예외 발생 테스트")
+    void getService_null_throwsException() {
+        // given
+        List<RoomService> roomServices = List.of();
+        RoomServiceFactory factory = new RoomServiceFactory(roomServices);
+        
+        // when & then
+        assertThatThrownBy(() -> factory.getService((RoomType) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("룸 타입이 null입니다");
+    }
+
+    @Test
+    @DisplayName("지원되는 룸 타입 확인 테스트")
+    void isSupported_true() {
+        // given
+        given(aiRoomService.getSupportedRoomType()).willReturn(RoomType.AI_GAME);
+        
+        List<RoomService> roomServices = List.of(aiRoomService);
+        RoomServiceFactory factory = new RoomServiceFactory(roomServices);
+        
+        // when
+        boolean result = factory.isSupported(RoomType.AI_GAME);
+        
+        // then
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION

# 요약

- AiGameMessage, AiGameRoom 엔티티의 시간 필드를 Instant로 변경
- 관련 DTO 및 Service 클래스도 함께 수정
- AiServiceRequest, AiGameMessageRepository, AiGameMessageService 테스트 코드 추가
- MongoDB TestContainers 및 Mockito를 활용한 포괄적 테스트 구현
# 연관 이슈 및 Close 할 이슈 작성

-- PR 시 다음과 같이 작성 
#60 

close #60 

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 채팅 메시지/게임방의 생성 시각을 Instant(UTC)로 통일했습니다. API 응답의 createdAt이 UTC ISO-8601 형식으로 제공됩니다. 클라이언트에서 시간대 변환을 적용하세요.
* Tests
  * DTO 직렬화/역직렬화, 메시지 저장소, 매칭 큐/서비스, 룸 서비스 팩토리 등 단위·통합 테스트를 추가해 안정성과 회귀 방지성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->