### PR TITLE
Feat dgt 71

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
@@ -12,7 +12,6 @@ import org.com.dungeontalk.domain.gamecharacter.dto.request.CreateCharacterReque
 import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterDetailResponse;
 import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterResponse;
 import org.com.dungeontalk.domain.gamecharacter.service.GameCharacterService;
-import org.com.dungeontalk.domain.stat.repository.RaceStatsRepository;
 import org.com.dungeontalk.global.rsData.RsData;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +25,6 @@ import java.util.List;
 public class GameCharacterController {
 
     private final GameCharacterService gameCharacterService;
-    private final RaceStatsRepository raceStatsRepository;
 
     // 새로운 캐릭터 생성 (캐릭터 생성 화면에서 사용)
     @Operation(summary = "캐릭터 생성", description = "새로운 캐릭터를 생성합니다. 레벨 1, 모든 스탯 10으로 초기화됩니다.")
@@ -37,7 +35,7 @@ public class GameCharacterController {
     })
     @PostMapping
     public RsData<GameCharacterResponse> createCharacter(@RequestBody CreateCharacterRequest request) {
-        var response = gameCharacterService.createCharacter(request);
+        GameCharacterResponse response = gameCharacterService.createCharacter(request);
         return RsData.of("201", "캐릭터 생성 완료", response);
     }
 
@@ -50,7 +48,7 @@ public class GameCharacterController {
     })
     @GetMapping("/basic/{id}")
     public RsData<GameCharacterResponse> getCharacterBasic(@PathVariable String id) {
-        var response = gameCharacterService.findById(id);
+        GameCharacterResponse response = gameCharacterService.findById(id);
         return RsData.of("200", "캐릭터 조회 완료", response);
     }
 
@@ -63,7 +61,7 @@ public class GameCharacterController {
     })
     @GetMapping("/{id}")
     public RsData<GameCharacterDetailResponse> getCharacterDetail(@PathVariable String id) {
-        var response = gameCharacterService.findDetailById(id);
+        GameCharacterDetailResponse response = gameCharacterService.findDetailById(id);
         return RsData.of("200", "캐릭터 상세 조회 완료", response);
     }
 
@@ -76,7 +74,7 @@ public class GameCharacterController {
     })
     @GetMapping
     public RsData<GameCharacterResponse> getCharacterByMember(@RequestParam String memberId) {
-        var response = gameCharacterService.findByMemberId(memberId);
+        GameCharacterResponse response = gameCharacterService.findByMemberId(memberId);
         return RsData.of("200", "멤버 캐릭터 조회 완료", response);
     }
 
@@ -88,7 +86,7 @@ public class GameCharacterController {
     })
     @GetMapping("/races")
     public RsData<List<String>> getRaces() {
-        var races = raceStatsRepository.findAllRaceNames();
+        List<String> races = gameCharacterService.getRaces();
         return RsData.of("200", "종족 목록 조회 완료", races);
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
@@ -13,7 +13,6 @@ import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterDetail
 import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterResponse;
 import org.com.dungeontalk.domain.gamecharacter.service.GameCharacterService;
 import org.com.dungeontalk.global.rsData.RsData;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/controller/GameCharacterController.java
@@ -37,8 +37,7 @@ public class GameCharacterController {
     })
     @PostMapping
     public RsData<GameCharacterResponse> createCharacter(@RequestBody CreateCharacterRequest request) {
-        var character = gameCharacterService.createCharacter(request);
-        var response = GameCharacterResponse.from(character);
+        var response = gameCharacterService.createCharacter(request);
         return RsData.of("201", "캐릭터 생성 완료", response);
     }
 
@@ -51,8 +50,7 @@ public class GameCharacterController {
     })
     @GetMapping("/basic/{id}")
     public RsData<GameCharacterResponse> getCharacterBasic(@PathVariable String id) {
-        var character = gameCharacterService.findById(id);
-        var response = GameCharacterResponse.from(character);
+        var response = gameCharacterService.findById(id);
         return RsData.of("200", "캐릭터 조회 완료", response);
     }
 
@@ -78,8 +76,7 @@ public class GameCharacterController {
     })
     @GetMapping
     public RsData<GameCharacterResponse> getCharacterByMember(@RequestParam String memberId) {
-        var character = gameCharacterService.findByMemberId(memberId);
-        var response = GameCharacterResponse.from(character);
+        var response = gameCharacterService.findByMemberId(memberId);
         return RsData.of("200", "멤버 캐릭터 조회 완료", response);
     }
 

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/entity/GameCharacter.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/entity/GameCharacter.java
@@ -7,6 +7,7 @@ import lombok.experimental.SuperBuilder;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import org.com.dungeontalk.domain.stat.entity.RaceStats;
+import org.com.dungeontalk.domain.member.entity.Member;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
 
 import java.util.HashMap;
@@ -25,6 +26,15 @@ public class GameCharacter extends BaseEntity {
 
     @Column(name = "member_id")
     private String memberId;
+
+    /**
+     * 멤버와의 일대일 관계 (읽기 전용)
+     * - member_id(FK)는 기존 필드 사용
+     * - 실제 갱신은 member_id 컬럼으로만 하고, 본 연관은 읽기 전용
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", referencedColumnName = "id", insertable = false, updatable = false)
+    private Member member;
 
     @Column(name = "race_type_id")
     private String raceTypeId;

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/entity/GameCharacter.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/entity/GameCharacter.java
@@ -3,6 +3,9 @@ package org.com.dungeontalk.domain.gamecharacter.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.com.dungeontalk.domain.stat.entity.RaceStats;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
 
@@ -11,6 +14,9 @@ import java.util.Map;
 
 @Getter
 @Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "character")
 public class GameCharacter extends BaseEntity {

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/service/GameCharacterService.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/service/GameCharacterService.java
@@ -3,6 +3,7 @@ package org.com.dungeontalk.domain.gamecharacter.service;
 import lombok.RequiredArgsConstructor;
 import org.com.dungeontalk.domain.gamecharacter.dto.request.CreateCharacterRequest;
 import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterDetailResponse;
+import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterResponse;
 import org.com.dungeontalk.domain.gamecharacter.entity.GameCharacter;
 import org.com.dungeontalk.domain.gamecharacter.repository.GameCharacterRepository;
 import org.com.dungeontalk.domain.stat.repository.RaceStatsRepository;
@@ -23,7 +24,7 @@ public class GameCharacterService {
 
     // 새로운 캐릭터 생성 (레벨 1, 모든 스탯 10으로 초기화)
     @Transactional
-    public GameCharacter createCharacter(CreateCharacterRequest request) {
+    public GameCharacterResponse createCharacter(CreateCharacterRequest request) {
         // 종족명으로 RaceStats 조회하여 UUID 가져오기
         var raceStats = raceStatsRepository.findByRace(request.raceTypeId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 종족: " + request.raceTypeId()));
@@ -43,25 +44,29 @@ public class GameCharacterService {
         character.setDex(10);
         character.setLuk(10);
 
-        return gameCharacterRepository.save(character);
+        GameCharacter savedCharacter = gameCharacterRepository.save(character);
+        return GameCharacterResponse.from(savedCharacter);
     }
 
     // 캐릭터 ID로 기본 정보 조회 (종족 스탯 없이)
-    public GameCharacter findById(String id) {
-        return gameCharacterRepository.findById(id)
+    public GameCharacterResponse findById(String id) {
+        GameCharacter character = gameCharacterRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Character not found: " + id));
+        return GameCharacterResponse.from(character);
     }
 
     // 캐릭터 ID로 조회 + 종족 스탯 정보 포함 (fetch join 사용), 프론트에 데이터 보낼 때 사용
-    public GameCharacter findByIdWithRace(String id) {
-        return gameCharacterRepository.findWithRace(id)
+    public GameCharacterResponse findByIdWithRace(String id) {
+        GameCharacter character = gameCharacterRepository.findWithRace(id)
                 .orElseThrow(() -> new IllegalArgumentException("Character not found: " + id));
+        return GameCharacterResponse.from(character);
     }
 
     // 멤버 ID로 해당 멤버의 캐릭터 조회 (MVP: 1개 멤버당 1개 캐릭터)
-    public GameCharacter findByMemberId(String memberId) {
-        return gameCharacterRepository.findByMemberId(memberId)
+    public GameCharacterResponse findByMemberId(String memberId) {
+        GameCharacter character = gameCharacterRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Character not found for member: " + memberId));
+        return GameCharacterResponse.from(character);
     }
 
     // 캐릭터 상세 정보 조회 (기본 정보 + 종족명 + 계산된 스탯)

--- a/src/main/java/org/com/dungeontalk/domain/gamecharacter/service/GameCharacterService.java
+++ b/src/main/java/org/com/dungeontalk/domain/gamecharacter/service/GameCharacterService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import org.com.dungeontalk.domain.stat.entity.RaceStats;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +28,7 @@ public class GameCharacterService {
     @Transactional
     public GameCharacterResponse createCharacter(CreateCharacterRequest request) {
         // 종족명으로 RaceStats 조회하여 UUID 가져오기
-        var raceStats = raceStatsRepository.findByRace(request.raceTypeId())
+        RaceStats raceStats = raceStatsRepository.findByRace(request.raceTypeId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 종족: " + request.raceTypeId()));
 
         GameCharacter character = new GameCharacter();
@@ -78,8 +80,13 @@ public class GameCharacterService {
         String raceName = character.getRaceStats().getRace();
 
         // 모든 스탯 계산
-        var calculatedStats = statAggregateService.calculateAllStats(id);
+        Map<String, Double> calculatedStats = statAggregateService.calculateAllStats(id);
 
         return GameCharacterDetailResponse.from(character, raceName, calculatedStats);
+    }
+
+    // 사용 가능한 모든 종족 목록 조회
+    public List<String> getRaces() {
+        return raceStatsRepository.findAllRaceNames();
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/member/dto/request/RegisterRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/dto/request/RegisterRequest.java
@@ -14,7 +14,10 @@ public record RegisterRequest(
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         // @Size(min = 2, max = 128, message = "비밀번호는 최소 2자 이상이어야 합니다.")
-        String password
+        String password,
+
+        @NotBlank(message = "종족을 선택해주세요.")
+        String raceTypeId
 ) {
     public Member toEntity(String encodedPassword) {
         return Member.builder()

--- a/src/main/java/org/com/dungeontalk/domain/member/dto/response/RegisterResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/dto/response/RegisterResponse.java
@@ -1,8 +1,11 @@
 package org.com.dungeontalk.domain.member.dto.response;
 
+import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterResponse;
+
 public record RegisterResponse(
         String id,
         String name,
-        String nickName
+        String nickName,
+        GameCharacterResponse character
 ) {
 }

--- a/src/main/java/org/com/dungeontalk/domain/member/service/MemberService.java
+++ b/src/main/java/org/com/dungeontalk/domain/member/service/MemberService.java
@@ -6,6 +6,9 @@ import org.com.dungeontalk.domain.member.dto.request.RegisterRequest;
 import org.com.dungeontalk.domain.member.dto.response.RegisterResponse;
 import org.com.dungeontalk.domain.member.entity.Member;
 import org.com.dungeontalk.domain.member.repository.MemberRepository;
+import org.com.dungeontalk.domain.gamecharacter.service.GameCharacterService;
+import org.com.dungeontalk.domain.gamecharacter.dto.request.CreateCharacterRequest;
+import org.com.dungeontalk.domain.gamecharacter.dto.response.GameCharacterResponse;
 import org.com.dungeontalk.global.security.JwtService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,7 @@ public class MemberService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+    private final GameCharacterService gameCharacterService;
 
     // 회원가입 메서드
     @Transactional
@@ -36,7 +40,19 @@ public class MemberService {
         Member member = registerRequest.toEntity(encodedPassword);
         memberRepository.save(member);
 
-        return new RegisterResponse(member.getId(), member.getName(), member.getNickName());
+        // 회원가입 시 캐릭터도 함께 생성
+        CreateCharacterRequest characterRequest = new CreateCharacterRequest(
+            member.getId(),
+            registerRequest.raceTypeId()
+        );
+        GameCharacterResponse characterResponse = gameCharacterService.createCharacter(characterRequest);
+
+        return new RegisterResponse(
+            member.getId(), 
+            member.getName(), 
+            member.getNickName(),
+            characterResponse
+        );
     }
 
 

--- a/src/main/java/org/com/dungeontalk/domain/stat/controller/DataInitController.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/controller/DataInitController.java
@@ -65,14 +65,14 @@ public class DataInitController {
         dwarf.setDiceOdds("luk * 0.10");
 
         List<RaceStats> raceStatsList = List.of(elf, human, dwarf);
-        var savedRaceStats = raceStatsRepository.saveAll(raceStatsList);
+        List<RaceStats> savedRaceStats = raceStatsRepository.saveAll(raceStatsList);
         return RsData.of("201", "RaceStats 생성 완료", savedRaceStats);
     }
 
     // 현재 등록된 모든 종족 스탯 데이터 조회
     @GetMapping("/race-stats")
     public RsData<List<RaceStats>> getAllRaceStats() {
-        var raceStats = raceStatsRepository.findAll();
+        List<RaceStats> raceStats = raceStatsRepository.findAll();
         return RsData.of("200", "RaceStats 조회 완료", raceStats);
     }
 

--- a/src/main/java/org/com/dungeontalk/domain/stat/controller/StatController.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/controller/StatController.java
@@ -11,6 +11,8 @@ import org.com.dungeontalk.domain.stat.service.StatAggregateService;
 import org.com.dungeontalk.global.rsData.RsData;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Tag(name = "스탯", description = "게임 내 캐릭터 스탯 관련 API")
 @RestController
 @RequestMapping("/v1/stat")
@@ -33,8 +35,8 @@ public class StatController {
     })
     @GetMapping("/{characterId}/calculated")
     public RsData<CalculatedStatsResponse> calculated(@PathVariable String characterId) {
-        var map = statAggregateService.calculateAllStats(characterId);
-        var response = CalculatedStatsResponse.fromMap(characterId, map);
+        Map<String, Double> map = statAggregateService.calculateAllStats(characterId);
+        CalculatedStatsResponse response = CalculatedStatsResponse.fromMap(characterId, map);
         return RsData.of("200", "스탯 계산 완료", response);
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/stat/controller/StatController.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/controller/StatController.java
@@ -11,8 +11,6 @@ import org.com.dungeontalk.domain.stat.service.StatAggregateService;
 import org.com.dungeontalk.global.rsData.RsData;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @Tag(name = "스탯", description = "게임 내 캐릭터 스탯 관련 API")
 @RestController
 @RequestMapping("/v1/stat")
@@ -34,9 +32,9 @@ public class StatController {
         @ApiResponse(responseCode = "404", description = "캐릭터 없음 또는 종족 스탯 공식 없음")
     })
     @GetMapping("/{characterId}/calculated")
-    public RsData<CalculatedStatsResponse> calculated(@PathVariable UUID characterId) {
-        var map = statAggregateService.calculateAllStats(characterId.toString()); // 리포/서비스가 String이면 변환
-        var response = CalculatedStatsResponse.fromMap(characterId.toString(), map);      // DTO가 String이면 변환
+    public RsData<CalculatedStatsResponse> calculated(@PathVariable String characterId) {
+        var map = statAggregateService.calculateAllStats(characterId);
+        var response = CalculatedStatsResponse.fromMap(characterId, map);
         return RsData.of("200", "스탯 계산 완료", response);
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/stat/entity/RaceStats.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/entity/RaceStats.java
@@ -5,10 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import org.com.dungeontalk.global.common.entity.BaseEntity;
 
 @Getter
 @Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "race_stats")
 public class RaceStats extends BaseEntity {

--- a/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
@@ -90,5 +90,4 @@ public class StatAggregateService {
 
         return result.toString();
     }
-
 }

--- a/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
@@ -37,21 +37,12 @@ public class StatAggregateService {
         Map<String, Object> variables = gameCharacter.toVariableMap();   // 필요 변수 준비(검증 추가는 이후 단계에서)
         Map<String, String> formulas  = extractFormulas(raceStats);  // 동적 추출(키=@Column name)
 
-        // 디버깅 로그 추가
-        System.out.println("[DEBUG] 캐릭터 ID: " + characterId);
-        System.out.println("[DEBUG] 종족: " + raceStats.getRace());
-        System.out.println("[DEBUG] 변수들: " + variables);
-        System.out.println("[DEBUG] 공식들: " + formulas);
-
         Map<String, Double> result = new LinkedHashMap<>();
         for (Map.Entry<String, String> e : formulas.entrySet()) {
-            System.out.println("[DEBUG] 계산 중: " + e.getKey() + " = " + e.getValue());
             double value = calculator.calculate(e.getValue(), variables);
-            System.out.println("[DEBUG] 계산 결과: " + e.getKey() + " = " + value);
 
             // 스네이크케이스를 카멜케이스로 변환
             String camelCaseKey = toCamelCase(e.getKey());
-            System.out.println("[DEBUG] 키 변환: " + e.getKey() + " → " + camelCaseKey);
             result.put(camelCaseKey, value);
         }
         return result;
@@ -100,9 +91,4 @@ public class StatAggregateService {
         return result.toString();
     }
 
-    /** (옵션) 디버그용 */
-    public void debugPrintAllStats(String characterId) {
-        calculateAllStats(characterId)
-                .forEach((k, v) -> System.out.println("[DEBUG] " + k + " = " + v));
-    }
 }

--- a/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
+++ b/src/main/java/org/com/dungeontalk/domain/stat/service/StatAggregateService.java
@@ -80,7 +80,7 @@ public class StatAggregateService {
         // 첫 번째 단어는 그대로, 나머지는 첫 글자만 대문자
         result.append(words[0]);
         for (int i = 1; i < words.length; i++) {
-            if (words[i].length() > 0) {
+            if (!words[i].isEmpty()) {
                 result.append(Character.toUpperCase(words[i].charAt(0)));
                 if (words[i].length() > 1) {
                     result.append(words[i].substring(1));

--- a/src/main/resources/static/character-test.html
+++ b/src/main/resources/static/character-test.html
@@ -104,12 +104,37 @@
         <div id="racesResult" class="result"></div>
     </div>
 
-    <!-- 캐릭터 생성 -->
+    <!-- 회원가입 + 캐릭터 생성 -->
     <div class="section">
-        <h2>2. 캐릭터 생성</h2>
+        <h2>2. 회원가입 + 캐릭터 생성</h2>
+        <div class="form-group">
+            <label>사용자 이름:</label>
+            <input type="text" id="registerName" placeholder="testUser123">
+        </div>
+        <div class="form-group">
+            <label>닉네임:</label>
+            <input type="text" id="registerNickName" placeholder="테스트유저">
+        </div>
+        <div class="form-group">
+            <label>비밀번호:</label>
+            <input type="password" id="registerPassword" placeholder="password123">
+        </div>
+        <div class="form-group">
+            <label>종족:</label>
+            <select id="registerRaceTypeId">
+                <option value="">종족을 선택하세요</option>
+            </select>
+        </div>
+        <button onclick="registerWithCharacter()">회원가입 + 캐릭터 생성</button>
+        <div id="registerResult" class="result"></div>
+    </div>
+
+    <!-- 기존 캐릭터 생성 (테스트용) -->
+    <div class="section">
+        <h2>2-1. 별도 캐릭터 생성 (테스트용)</h2>
         <div class="form-group">
             <label>멤버 ID:</label>
-            <input type="text" id="createMemberId" placeholder="user123" value="testUser001">
+            <input type="text" id="createMemberId" placeholder="실제 Member ID를 입력하세요">
         </div>
         <div class="form-group">
             <label>종족:</label>
@@ -185,17 +210,70 @@
             // RsData에서 실제 데이터 추출
             const races = rsData.data;
             
-            // 종족 선택박스에 옵션 추가
-            const select = document.getElementById('createRaceTypeId');
-            select.innerHTML = '<option value="">종족을 선택하세요</option>';
+            // 종족 선택박스에 옵션 추가 (회원가입용, 캐릭터생성용 둘 다)
+            const registerSelect = document.getElementById('registerRaceTypeId');
+            const createSelect = document.getElementById('createRaceTypeId');
+            
+            registerSelect.innerHTML = '<option value="">종족을 선택하세요</option>';
+            createSelect.innerHTML = '<option value="">종족을 선택하세요</option>';
+            
             races.forEach(race => {
-                const option = document.createElement('option');
-                option.value = race;
-                option.textContent = race;
-                select.appendChild(option);
+                const registerOption = document.createElement('option');
+                registerOption.value = race;
+                registerOption.textContent = race;
+                registerSelect.appendChild(registerOption);
+                
+                const createOption = document.createElement('option');
+                createOption.value = race;
+                createOption.textContent = race;
+                createSelect.appendChild(createOption);
             });
         } catch (error) {
             showResult('racesResult', { error: error.message }, true);
+        }
+    }
+
+    // 회원가입 + 캐릭터 생성
+    async function registerWithCharacter() {
+        const name = document.getElementById('registerName').value.trim();
+        const nickName = document.getElementById('registerNickName').value.trim();
+        const password = document.getElementById('registerPassword').value.trim();
+        const raceTypeId = document.getElementById('registerRaceTypeId').value;
+
+        if (!name || !nickName || !password || !raceTypeId) {
+            showResult('registerResult', { error: '모든 필드를 입력해주세요.' }, true);
+            return;
+        }
+
+        try {
+            const response = await fetch(`${API_BASE}/v1/member/register`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ 
+                    name: name, 
+                    nickName: nickName, 
+                    password: password,
+                    raceTypeId: raceTypeId 
+                })
+            });
+
+            const rsData = await response.json();
+            showResult('registerResult', rsData);
+
+            if (response.ok && rsData.resultCode === '200') {
+                // 성공 시 생성된 멤버 정보 표시
+                const memberData = rsData.data;
+                console.log('회원가입 + 캐릭터 생성 성공:', memberData);
+                
+                // 생성된 멤버 ID를 다른 입력폼에 자동 입력 (테스트용)
+                if (memberData && memberData.id) {
+                    document.getElementById('createMemberId').value = memberData.id;
+                }
+            }
+        } catch (error) {
+            showResult('registerResult', { error: error.message }, true);
         }
     }
 


### PR DESCRIPTION
# 요약

코드 리팩토링 및 계정 생성 시 캐릭터도 같이 생성되도록 추가

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#71

close #71

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 회원가입과 동시에 캐릭터가 자동 생성되며, 응답에 캐릭터 정보가 포함됩니다.
  * 테스트 페이지에 “회원가입 + 캐릭터 생성” 흐름과 별도 캐릭터 생성 섹션이 추가되었습니다.
  * 회원가입 시 종족 선택이 필수이며, 종족 목록 드롭다운이 자동으로 로드됩니다.
  * 등록 성공 시 결과가 표시되고, 생성된 멤버 ID가 후속 테스트 입력란에 자동 채워집니다.
* 리팩터
  * 스탯 계산 API가 캐릭터 ID를 문자열로 받도록 변경되었습니다.
  * 여러 엔드포인트의 응답이 DTO 중심으로 일관화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->