### PR TITLE
fix(login) - 로그인 시 uuid, refreshtoken등 민감 정보 제거

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.com.dungeontalk.domain.auth.dto.request.AuthLoginRequest;
 import org.com.dungeontalk.domain.auth.dto.request.RefreshTokenRequest;
 import org.com.dungeontalk.domain.auth.dto.response.AuthLoginResponse;
 import org.com.dungeontalk.domain.auth.dto.response.JwtTokenResponse;
+import org.com.dungeontalk.domain.auth.dto.response.TokenResponse;
 import org.com.dungeontalk.domain.auth.service.AuthService;
 import org.com.dungeontalk.global.rsData.RsData;
 import org.springframework.web.bind.annotation.*;
@@ -28,12 +29,12 @@ public class AuthController {
             HttpServletResponse httpServletResponse) throws InterruptedException {
 
         // 로그인 서비스 레이어 호출
-        AuthLoginResponse jwtTokenResponse = authService.login(request,httpServletRequest);
+        TokenResponse tokenResponse = authService.login(request,httpServletRequest);
 
         // 쿠키에 리프레시 토큰 저장
-        authService.saveRefreshTokenToCookie(httpServletResponse, jwtTokenResponse.refreshToken());
+        authService.saveRefreshTokenToCookie(httpServletResponse, tokenResponse.getRefreshToken());
 
-        return RsData.of("200", "로그인 성공", jwtTokenResponse);
+        return RsData.of("200", "로그인 성공", new AuthLoginResponse(tokenResponse.getAccessToken()));
     }
 
     // JWT 토큰 재발급

--- a/src/main/java/org/com/dungeontalk/domain/auth/dto/response/AuthLoginResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/dto/response/AuthLoginResponse.java
@@ -1,8 +1,6 @@
 package org.com.dungeontalk.domain.auth.dto.response;
 
 public record AuthLoginResponse(
-        String memberId,
-        String accessToken,
-        String refreshToken
+        String accessToken
 ) {
 }

--- a/src/main/java/org/com/dungeontalk/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package org.com.dungeontalk.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
+++ b/src/main/java/org/com/dungeontalk/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.auth.dto.request.AuthLoginRequest;
 import org.com.dungeontalk.domain.auth.dto.response.AuthLoginResponse;
 import org.com.dungeontalk.domain.auth.dto.response.JwtTokenResponse;
+import org.com.dungeontalk.domain.auth.dto.response.TokenResponse;
 import org.com.dungeontalk.domain.auth.entity.Auth;
 import org.com.dungeontalk.domain.auth.manager.ActualLoginManager;
 import org.com.dungeontalk.domain.auth.manager.AuthRedisManager;
@@ -38,13 +39,13 @@ public class AuthService {
     private final ActualLoginManager actualLoginManager;
 
     // 보안 기능이 추가 된 로그인 메서드
-    public AuthLoginResponse login(AuthLoginRequest request, HttpServletRequest httpServletRequest) throws InterruptedException {
+    public TokenResponse login(AuthLoginRequest request, HttpServletRequest httpServletRequest) throws InterruptedException {
 
         bruteForceManager.preCheck(request.name(), httpServletRequest); // 로그인 시도 전 이상 행동 존재 유무 체크
         try {
-            AuthLoginResponse authLoginResponse = actualLogin(request); // 실질적인 로그인 메서드 호출
+            TokenResponse tokenResponse = actualLogin(request); // 실질적인 로그인 메서드 호출
             bruteForceManager.loginSucceeded(request.name()); // 로그인 성공시 기존 실패/정지 기록 삭제
-            return authLoginResponse;
+            return tokenResponse;
         } catch (MemberException ex) {
             bruteForceManager.loginFailed(request.name()); // Delay, Cool Down 방어
             throw ex;
@@ -52,13 +53,13 @@ public class AuthService {
     }
 
     // 실질적인 로그인 메서드
-    public AuthLoginResponse actualLogin(AuthLoginRequest request) {
+    public TokenResponse actualLogin(AuthLoginRequest request) {
 
         Member member = actualLoginManager.validateMember(request); // 유저 검증
         JwtTokenResponse jwtTokenResponse = actualLoginManager.generateToken(member); // JWT 토큰 생성
         actualLoginManager.updateMemberRefreshToken(member, jwtTokenResponse); // RefreshToken 갱신
 
-        return new AuthLoginResponse(member.getId(),
+        return new TokenResponse(
                 jwtTokenResponse.getAccessToken(),
                 jwtTokenResponse.getRefreshToken()
         );


### PR DESCRIPTION
# 요약

기존의 UUID, RefreshToken을 제외하였습니다.

<img width="1365" height="681" alt="image" src="https://github.com/user-attachments/assets/5f8b828b-2e03-466f-a9b6-111a6aa037df" />


# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#89 

close #89 

# Pull Request 체크리스트

## TODO

- [v ] 최종 결과물을 확인했는가?
- [ v] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 로그인 API 응답 구조가 단순화되었습니다: 이제 accessToken만 반환합니다.
  - refresh token은 서버에 안전하게 보관되며 더 이상 클라이언트로 전달되지 않습니다.
  - 기존에 응답의 memberId 또는 refreshToken에 의존하던 클라이언트는 해당 로직을 제거/수정해야 합니다.
  - 응답 모델 변경으로 직렬화 포맷이 간소화되었으며, 통합 테스트 및 클라이언트 연동 시 호환성 점검이 필요합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->