### PR TITLE
feat(AI Chat): 게임 세계관 설정을 AI 서비스로 전달하는 기능 추가

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequest.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequest.java
@@ -32,4 +32,7 @@ public class AiServiceRequest {
     
     @JsonProperty("turn_number")
     private int turnNumber;
+    
+    @JsonProperty("game_settings")
+    private String gameSettings;
 }

--- a/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameRoomResponse.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/dto/response/AiGameRoomResponse.java
@@ -51,6 +51,9 @@ public class AiGameRoomResponse {
     @Schema(description = "참가자 목록")
     private List<String> participants;
     
+    @Schema(description = "게임 설정 (세계관)", example = "중세 판타지 세계관에서 펼쳐지는 마법과 모험의 이야기")
+    private String gameSettings;
+    
     @Schema(description = "생성 시간")
     private Instant createdAt;
 
@@ -86,6 +89,7 @@ public class AiGameRoomResponse {
                 .participants(Optional.ofNullable(room.getParticipants())
                         .map(ArrayList::new)
                         .orElseGet(ArrayList::new))
+                .gameSettings(room.getGameSettings())
                 .createdAt(room.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/com/dungeontalk/domain/aichat/service/AiApiService.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/service/AiApiService.java
@@ -7,6 +7,7 @@ import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
 import org.com.dungeontalk.domain.aichat.dto.request.AiServiceRequest;
 import org.com.dungeontalk.domain.aichat.dto.request.ContextMessage;
 import org.com.dungeontalk.domain.aichat.dto.response.AiServiceResponse;
+import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class AiApiService {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
+    private final AiGameRoomService aiGameRoomService;
 
     @Value("${ai.service.url:http://localhost:8001}")
     private String aiServiceUrl;
@@ -46,6 +48,12 @@ public class AiApiService {
             log.info("Python AI 서비스 호출 시작: roomId={}, user={}, turn={}", 
                      aiGameRoomId, currentUser, turnNumber);
 
+            // 게임방 정보 조회하여 gameSettings 가져오기
+            AiGameRoomResponse roomResponse = aiGameRoomService.getAiGameRoom(aiGameRoomId);
+            String gameSettings = roomResponse.getGameSettings();
+            
+            log.debug("게임 세계관 설정: {}", gameSettings);
+
             // 요청 데이터 구성
             AiServiceRequest request = AiServiceRequest.builder()
                     .gameId(gameId)
@@ -56,6 +64,7 @@ public class AiApiService {
                             .map(this::convertToContextMessage)
                             .toList())
                     .turnNumber(turnNumber)
+                    .gameSettings(gameSettings)
                     .build();
 
             // HTTP 헤더 설정

--- a/src/main/resources/static/dungeon-game.html
+++ b/src/main/resources/static/dungeon-game.html
@@ -21,6 +21,20 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             color: #333;
+            transition: background 0.8s ease;
+        }
+        
+        /* 세계관별 배경 테마 */
+        body.theme-fantasy {
+            background: linear-gradient(135deg, #8B4513 0%, #DAA520 50%, #2E8B57 100%);
+        }
+        
+        body.theme-scifi {
+            background: linear-gradient(135deg, #000428 0%, #004e92 50%, #009ffd 100%);
+        }
+        
+        body.theme-modern {
+            background: linear-gradient(135deg, #2C3E50 0%, #34495E 50%, #7F8C8D 100%);
         }
         
         .container {
@@ -139,9 +153,25 @@
         }
         
         .world-card.selected {
-            background: linear-gradient(135deg, #007bff, #0056b3);
             color: white;
             border-color: #007bff;
+            transform: translateY(-5px) scale(1.05);
+            box-shadow: 0 15px 35px rgba(0,0,0,0.2);
+        }
+        
+        .world-card.selected[data-world="FANTASY"] {
+            background: linear-gradient(135deg, #8B4513, #DAA520);
+            border-color: #DAA520;
+        }
+        
+        .world-card.selected[data-world="SCIFI"] {
+            background: linear-gradient(135deg, #004e92, #009ffd);
+            border-color: #009ffd;
+        }
+        
+        .world-card.selected[data-world="MODERN"] {
+            background: linear-gradient(135deg, #2C3E50, #7F8C8D);
+            border-color: #7F8C8D;
         }
         
         .world-card h3 {
@@ -431,6 +461,10 @@
                     <strong>매칭 정보</strong>
                     <div id="matchingInfo">대기 중</div>
                 </div>
+                <div class="status-card" id="worldInfoCard" style="display: none;">
+                    <strong>선택된 세계관</strong>
+                    <div id="selectedWorldInfo">-</div>
+                </div>
                 <div class="status-card">
                     <strong>게임방</strong>
                     <div id="roomInfo">미연결</div>
@@ -460,16 +494,22 @@
             <h3>🌍 세계관 선택 & 매칭</h3>
             <div class="world-selection">
                 <div class="world-card" onclick="selectWorld('FANTASY')" data-world="FANTASY">
-                    <h3>🏰 판타지</h3>
-                    <p>마법과 검이 지배하는 중세 판타지 세계에서 모험을 떠나보세요. 드래곤, 마법사, 기사들과 함께하는 대서사시가 펼쳐집니다.</p>
+                    <h3>🏰 판타지 세계</h3>
+                    <p>⚔️ 마법과 검의 전설적 모험<br>
+                    🌲 드래곤, 엘프, 드워프들과 함께<br>
+                    ✨ 고대의 던전과 마법 아이템들</p>
                 </div>
                 <div class="world-card" onclick="selectWorld('SCIFI')" data-world="SCIFI">
-                    <h3>🚀 SF</h3>
-                    <p>미래 우주 시대의 첨단 기술과 외계 문명을 탐험하세요. 로봇, AI, 우주선으로 가득한 사이버네틱 어드벤처가 기다립니다.</p>
+                    <h3>🚀 사이버펑크 SF</h3>
+                    <p>🤖 AI와 첨단 기술의 미래<br>
+                    🌌 네오니 도시와 우주 정거장<br>
+                    ⚡ 해킹과 사이버네틱 스릴러</p>
                 </div>
                 <div class="world-card" onclick="selectWorld('MODERN')" data-world="MODERN">
-                    <h3>🏙️ 현대</h3>
-                    <p>현대 도시 세계관에서 펼쳐지는 일상과 미스터리의 이야기. 도시의 숨겨진 비밀들을 탐험해보세요.</p>
+                    <h3>🏙️ 현대 미스터리</h3>
+                    <p>🕵️‍♂️ 도시의 숨겨진 진실과 음모<br>
+                    📱 현실적인 배경과 기술<br>
+                    🏭 사건 수사와 추리 어드벤처</p>
                 </div>
             </div>
             
@@ -683,13 +723,21 @@
                     const responseData = await response.json();
                     const loginData = responseData.data;
                     
+                    console.log('로그인 응답 데이터:', loginData);
+                    
                     // JWT 토큰 저장
                     authToken = loginData.accessToken;
-                    currentUser = {
-                        id: loginData.memberId,
-                        name: userId,
-                        nickname: userId
-                    };
+                    
+                    // JWT 토큰에서 사용자 정보 추출
+                    currentUser = extractUserInfoFromToken(authToken);
+                    
+                    if (!currentUser) {
+                        console.error('JWT 토큰에서 사용자 정보를 추출할 수 없습니다.');
+                        alert('로그인 오류: 사용자 정보를 가져올 수 없습니다.');
+                        return;
+                    }
+                    
+                    console.log('JWT에서 추출한 사용자 정보:', currentUser);
                     
                     localStorage.setItem('authToken', authToken);
                     localStorage.setItem('currentUser', JSON.stringify(currentUser));
@@ -716,18 +764,80 @@
             document.querySelector(`[data-world="${worldType}"]`).classList.add('selected');
             selectedWorld = worldType;
             
+            // 배경 테마 적용
+            applyWorldTheme(worldType);
+            
+            // 세계관 정보 표시
+            updateWorldInfo(worldType);
+            
             // 매칭 시작 버튼 활성화
             document.getElementById('startMatchingBtn').disabled = false;
             
+            console.log(`✨ ${getWorldName(worldType)} 세계관 선택됨`);
         }
         
         function getWorldName(worldType) {
             const names = {
                 'FANTASY': '🏰 판타지',
-                'SF': '🚀 SF', 
+                'SCIFI': '🚀 SF', 
                 'MODERN': '🏙️ 현대'
             };
             return names[worldType] || worldType;
+        }
+        
+        // 세계관 테마 적용
+        function applyWorldTheme(worldType) {
+            // 기존 테마 클래스 제거
+            document.body.classList.remove('theme-fantasy', 'theme-scifi', 'theme-modern');
+            
+            // 새 테마 클래스 추가
+            switch(worldType) {
+                case 'FANTASY':
+                    document.body.classList.add('theme-fantasy');
+                    updateAiChatInfo('🏰 중세 판타지 세계에서의 모험이 시작됩니다! 마법과 검의 세계에서 용감한 행동을 취해보세요.');
+                    updatePlaceholders('마법사에게 말을 걸어본다', '동료들과 전략을 논의해보세요');
+                    break;
+                case 'SCIFI':
+                    document.body.classList.add('theme-scifi');
+                    updateAiChatInfo('🚀 미래 사이버펑크 세계에 오신 것을 환영합니다! 첨단 기술과 함께 스릴러를 경험해보세요.');
+                    updatePlaceholders('터미널을 해킹해본다', '팀원들과 미션을 계획하세요');
+                    break;
+                case 'MODERN':
+                    document.body.classList.add('theme-modern');
+                    updateAiChatInfo('🏙️ 현대 도시의 미스터리 세계입니다! 현실적인 상황에서 추리와 탐험을 즐겨보세요.');
+                    updatePlaceholders('주변을 자세히 살펴본다', '동료들과 정보를 공유하세요');
+                    break;
+            }
+        }
+        
+        // 세계관 정보 업데이트
+        function updateWorldInfo(worldType) {
+            const worldInfoCard = document.getElementById('worldInfoCard');
+            const selectedWorldInfo = document.getElementById('selectedWorldInfo');
+            
+            worldInfoCard.style.display = 'block';
+            selectedWorldInfo.textContent = getWorldName(worldType);
+        }
+        
+        // AI 채팅 정보 업데이트
+        function updateAiChatInfo(message) {
+            const aiChatInfo = document.getElementById('aiChatInfo');
+            if (aiChatInfo) {
+                aiChatInfo.textContent = message;
+            }
+        }
+        
+        // 플레이스홀더 업데이트
+        function updatePlaceholders(aiPlaceholder, userPlaceholder) {
+            const aiInput = document.getElementById('aiMessageInput');
+            const userInput = document.getElementById('userMessageInput');
+            
+            if (aiInput) {
+                aiInput.placeholder = `${aiPlaceholder} (예시 행동)`;
+            }
+            if (userInput) {
+                userInput.placeholder = userPlaceholder;
+            }
         }
         
         // 매칭 WebSocket 연결
@@ -952,10 +1062,8 @@
                     // 입력 활성화
                     enableChatInputs();
                     
-                    // 환영 메시지
-                    addAiMessage('system', `🌟 ${getWorldName(selectedWorld)} 세계에 오신 것을 환영합니다!`);
-                    addAiMessage('system', '🤖 AI 마스터가 여러분의 모험을 안내할 것입니다.');
-                    addAiMessage('ai', `안녕하세요 모험가들! 저는 여러분의 게임 마스터 AI입니다. ${getWorldName(selectedWorld)} 세계에서 펼쳐진 모험을 함께 만들어갑시다. 먼저 자기소개를 해주세요!`);
+                    // 세계관별 환영 메시지
+                    addWorldSpecificWelcomeMessages(selectedWorld);
                     
                     addUserMessage('system', '💬 플레이어들과의 채팅이 시작되었습니다!');
                     addUserMessage('system', `참여자: ${matchData.participants.join(', ')}`);
@@ -1331,6 +1439,61 @@
         
         function incrementTurnNumber() {
             currentTurnNumber++;
+        }
+        
+        // JWT 토큰 디코딩 함수
+        function decodeJWT(token) {
+            try {
+                // JWT는 3부분으로 나뉘어지는데, 두 번째 부분이 payload
+                const base64Url = token.split('.')[1];
+                const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+                const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+                    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+                }).join(''));
+                
+                return JSON.parse(jsonPayload);
+            } catch (error) {
+                console.error('JWT 디코딩 오류:', error);
+                return null;
+            }
+        }
+        
+        // JWT에서 사용자 정보 추출
+        function extractUserInfoFromToken(token) {
+            const payload = decodeJWT(token);
+            if (payload) {
+                return {
+                    id: payload.id || payload.sub, // subject 또는 id 필드 사용
+                    name: payload.name,
+                    nickname: payload.nickName
+                };
+            }
+            return null;
+        }
+        
+        // 세계관별 환영 메시지
+        function addWorldSpecificWelcomeMessages(worldType) {
+            switch(worldType) {
+                case 'FANTASY':
+                    addAiMessage('system', '🌟 중세 판타지 세계에 오신 것을 환영합니다!');
+                    addAiMessage('system', '⚔️ 마법과 검의 세계에서 전설적인 모험을 시작하세요!');
+                    addAiMessage('ai', '안녕하세요, 용감한 모험가들이여! 저는 여러분의 운명을 안내하는 고대의 지식을 가진 AI 오라클입니다. 이 신비로운 대륙에서 여러분의 영웅적인 여정이 시작됩니다. 먼저 자신을 소개하고, 어떤 모험을 찾고 있는지 말이어 주세요.');
+                    break;
+                case 'SCIFI':
+                    addAiMessage('system', '🚀 사이버펑크 2087년, 네오-토쿄 시티에 오신 것을 환영합니다!');
+                    addAiMessage('system', '🤖 첨단 기술과 AI가 지배하는 미래 세계입니다!');
+                    addAiMessage('ai', '안녕하세요, 에이전트들. 저는 네오-토쿄의 중앙 AI 시스템입니다. 여러분의 뇌랑 칩이 전닥적으로 중요한 미션에 선발되었습니다. 본 AI는 여러분의 작전을 지원하고 상황을 분석할 것입니다. 먼저 각자 자신의 코드네임과 전문분야를 보고해 주십시오.');
+                    break;
+                case 'MODERN':
+                    addAiMessage('system', '🏙️ 현대 도시의 미스터리 세계에 오신 것을 환영합니다!');
+                    addAiMessage('system', '🕵️‍♂️ 진실과 거짓이 얽혀 있는 현실 세계입니다!');
+                    addAiMessage('ai', '안녕하세요, 여러분. 저는 이 사건을 담당하게 된 전문 상담사 AI입니다. 최근 이 도시에서 발생한 기묘한 사건들을 조사하기 위해 여러분이 모인 것으로 알고 있습니다. 각자 자신의 배경과 이 사건에 관심을 갖게 된 이유를 설명해 주세요.');
+                    break;
+                default:
+                    addAiMessage('system', `🌟 ${getWorldName(selectedWorld)} 세계에 오신 것을 환영합니다!`);
+                    addAiMessage('system', '🤖 AI 마스터가 여러분의 모험을 안내할 것입니다.');
+                    addAiMessage('ai', `안녕하세요 모험가들! 저는 여러분의 게임 마스터 AI입니다. ${getWorldName(selectedWorld)} 세계에서 펼쳐진 모험을 함께 만들어갑시다. 먼저 자기소개를 해주세요!`);
+            }
         }
         
     </script>


### PR DESCRIPTION

# 요약
- AiServiceRequest에 gameSettings 필드 추가하여 세계관별 AI 응답 지원
- AiGameRoomResponse에 gameSettings 필드 추가 및 매핑 로직 구현
- AiApiService에서 게임방 정보를 조회하여 세계관 설정을 Python AI 서비스로 전달
- 판타지/SF/현대 세계관에 따른 맞춤형 AI 응답 생성 가능


# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#94 

close #94

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - AI 게임 방에 ‘게임 설정(세계관·룰)’ 정보 지원: 방 정보에서 설정 확인 가능, AI 요청에 반영되어 일관된 스토리텔링 제공.
  - 게임별 테마 및 세계관 UI 개선: 세계별 테마, 카드 스타일, 설명 및 세계정보 표시 추가.
  - 세계별 환영 메시지·프롬프트 자동 적용으로 시작 대화가 세계관에 맞게 변경됨.
  - JWT 기반 사용자 추출 및 로그인 처리 개선으로 사용자 정보 저장 및 흐름 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->