### PR TITLE
[fix] Matching Thread Pool 설정추가

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -31,9 +31,10 @@ jwt.secret=${JWT_SECRET}
 jwt.accessexpiration=${JWT_ACCESS_EXPIRATION:604800000}
 jwt.refreshexpiration=${JWT_REFRESH_EXPIRATION:604800000}
 
-# === aichat ===
-aichat.session.timeout-seconds=${AICHAT_SESSION_TIMEOUT_SECONDS:3600}
-aichat.session.turn-lock-timeout-seconds=${AICHAT_TURN_LOCK_TIMEOUT_SECONDS:300}
+# === aichat (AWS 환경 최적화) ===
+aichat.session.timeout-seconds=${AICHAT_SESSION_TIMEOUT_SECONDS:7200}
+aichat.session.turn-lock-timeout-seconds=${AICHAT_TURN_LOCK_TIMEOUT_SECONDS:600}
+aichat.session.heartbeat-interval-seconds=${AICHAT_HEARTBEAT_INTERVAL_SECONDS:30}
 aichat.context.message-count=${AICHAT_CONTEXT_MESSAGE_COUNT:5}
 aichat.websocket.destination-prefix=${AICHAT_WEBSOCKET_DESTINATION_PREFIX:/sub/aichat/room/}
 aichat.message-order.turn-start=${AICHAT_MESSAGE_ORDER_TURN_START:0}
@@ -55,7 +56,19 @@ profanity-filter.filter-admin-messages=${PROFANITY_FILTER_FILTER_ADMIN_MESSAGES:
 # Actuator
 management.endpoints.web.exposure.include=${MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE:health,info}
 
-# AI Service Configuration
+# AI Service Configuration (AWS 최적화)
 ai.service.url=${AI_SERVICE_URI}
-ai.service.timeout=${AI_SERVICE_TIMEOUT}
-ai.service.connect.timeout=${AI_SERVICE_CONNECT_TIMEOUT}
+ai.service.timeout=${AI_SERVICE_TIMEOUT:120000}
+ai.service.connect.timeout=${AI_SERVICE_CONNECT_TIMEOUT:30000}
+
+# === Matching Thread Pool (AWS 환경 최적화) ===
+app.matching.thread-pool.core-pool-size=${MATCHING_CORE_POOL_SIZE:5}
+app.matching.thread-pool.max-pool-size=${MATCHING_MAX_POOL_SIZE:20}
+app.matching.thread-pool.queue-capacity=${MATCHING_QUEUE_CAPACITY:100}
+app.matching.thread-pool.keep-alive-seconds=${MATCHING_KEEP_ALIVE_SECONDS:300}
+
+# === Logging (AWS CloudWatch 최적화) ===
+logging.level.org.com.dungeontalk.domain.matching=INFO
+logging.level.org.springframework.web.socket=WARN
+logging.level.org.springframework.messaging=WARN
+logging.level.root=INFO


### PR DESCRIPTION
# 요약
[fix] Matching Thread Pool 설정추가

# 연관 이슈 및 Close 할 이슈 작성
[fix] Matching Thread Pool 설정추가
<img width="786" height="255" alt="image" src="https://github.com/user-attachments/assets/1f6af0f4-722b-4b5c-a561-d041e76c05a0" />

-- PR 시 다음과 같이 작성 
#120 

close #120 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 프로덕션(AWS) 최적화 구성 적용: AI 서비스 타임아웃 기본값(응답 120초, 연결 30초) 반영.
  - aichat 세션 파라미터 조정: 세션 타임아웃 2시간, 턴 락 10분, 하트비트 30초 추가로 실시간 연결 안정성 강화.
  - 매칭 스레드 풀 기본값 설정: 코어 5, 최대 20, 큐 100, 유휴 300초로 처리량 향상.
  - 로깅 레벨 정비: 도메인/루트 INFO, WebSocket·Messaging WARN으로 잡음 감소 및 모니터링 가독성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->