### PR TITLE
[fix] WebSocket 연결 끊김 관련 설정 확인 및 수정

### DIFF
--- a/src/main/java/org/com/dungeontalk/domain/aichat/controller/AiChatStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/aichat/controller/AiChatStompController.java
@@ -1,5 +1,6 @@
 package org.com.dungeontalk.domain.aichat.controller;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.aichat.common.AiMessageType;
@@ -26,7 +27,7 @@ public class AiChatStompController {
      * AI 채팅은 턴제로 동작하므로 AI 응답 중에는 메시지 전송이 차단된다.
      */
     @MessageMapping("/aichat/send")
-    public RsData<String> sendMessage(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> sendMessage(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleWebSocketMessage(request);
     }
 
@@ -34,7 +35,7 @@ public class AiChatStompController {
      * 게임방 입장을 위한 엔드포인트
      */
     @MessageMapping("/aichat/join")
-    public RsData<String> joinRoom(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> joinRoom(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleJoinRoom(request);
     }
 
@@ -42,7 +43,7 @@ public class AiChatStompController {
      * 게임방 퇴장을 위한 엔드포인트
      */
     @MessageMapping("/aichat/leave")
-    public RsData<String> leaveRoom(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> leaveRoom(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleLeaveRoom(request);
     }
 
@@ -53,7 +54,7 @@ public class AiChatStompController {
      * 일반적으로 게임 로직에서 호출되며, 플레이어에게 턴 시작을 알린다.
      */
     @MessageMapping("/aichat/turn/start")
-    public RsData<String> startTurn(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> startTurn(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleStartTurn(request);
     }
 
@@ -64,7 +65,7 @@ public class AiChatStompController {
      * AI 서비스에서 응답 생성 완료 후 호출된다.
      */
     @MessageMapping("/aichat/turn/end")
-    public RsData<String> endTurn(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> endTurn(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleEndTurn(request);
     }
 
@@ -75,7 +76,7 @@ public class AiChatStompController {
      * 파이썬 AI 서비스에서 게임 종료 조건을 감지하면 호출된다.
      */
     @MessageMapping("/aichat/game/end")
-    public RsData<String> endGame(@Payload AiGameMessageSendRequest request) {
+    public RsData<String> endGame(@Payload AiGameMessageSendRequest request, HttpSession session) {
         return aiGameMessageService.handleGameEnd(request);
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/controller/ChatStompController.java
@@ -2,6 +2,7 @@ package org.com.dungeontalk.domain.chat.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,7 @@ public class ChatStompController {
      * 이후 ChatMessageService가 메시지의 타입에 따라 처리(JOIN, LEAVE, TALK)
      */
     @MessageMapping("/chat/send") // /pub/chat/send
-    public void sendMessage(@Valid @Payload ChatMessageSendRequestDto dto) throws JsonProcessingException {
+    public void sendMessage(@Valid @Payload ChatMessageSendRequestDto dto, HttpSession session) throws JsonProcessingException {
         if (log.isDebugEnabled()) {
             log.debug("STOMP 수신: {}", objectMapper.writeValueAsString(dto));
         }

--- a/src/main/java/org/com/dungeontalk/domain/matching/controller/MatchingWebSocketController.java
+++ b/src/main/java/org/com/dungeontalk/domain/matching/controller/MatchingWebSocketController.java
@@ -1,5 +1,6 @@
 package org.com.dungeontalk.domain.matching.controller;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.matching.dto.request.MatchingJoinRequest;
@@ -25,7 +26,7 @@ public class MatchingWebSocketController {
      */
     @MessageMapping("/matching/join")
     @SendToUser("/sub/matching/user")
-    public void joinMatching(@Payload MatchingJoinRequest request) {
+    public void joinMatching(@Payload MatchingJoinRequest request, HttpSession session) {
         WorldType worldType = worldTypeCompatService.valueOf(request.getWorldTypeCode());
         matchingService.handleWebSocketJoinMatching(request.getMemberId(), worldType);
     }
@@ -35,7 +36,7 @@ public class MatchingWebSocketController {
      */
     @MessageMapping("/matching/cancel")
     @SendToUser("/sub/matching/user")
-    public void cancelMatching(@Payload MatchingCancelRequest request) {
+    public void cancelMatching(@Payload MatchingCancelRequest request, HttpSession session) {
         matchingService.handleWebSocketCancelMatching(request.getMemberId());
     }
 }

--- a/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
+++ b/src/main/java/org/com/dungeontalk/domain/room/controller/UnifiedStompController.java
@@ -1,5 +1,6 @@
 package org.com.dungeontalk.domain.room.controller;
 
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.com.dungeontalk.domain.room.dto.UnifiedMessageRequest;
@@ -34,7 +35,7 @@ public class UnifiedStompController {
      */
     @MessageMapping("/room/{roomType}/send")
     public void sendMessage(@DestinationVariable String roomType, 
-                          @Valid @Payload UnifiedMessageRequest request) {
+                          @Valid @Payload UnifiedMessageRequest request, HttpSession session) {
         try {
             unifiedStompService.sendMessage(roomType, request);
         } catch (Exception e) {
@@ -50,7 +51,7 @@ public class UnifiedStompController {
      */
     @MessageMapping("/room/{roomType}/join")
     public void joinRoom(@DestinationVariable String roomType,
-                        @Valid @Payload UnifiedMessageRequest request) {
+                        @Valid @Payload UnifiedMessageRequest request, HttpSession session) {
         try {
             unifiedStompService.joinRoom(roomType, request);
         } catch (Exception e) {
@@ -65,7 +66,7 @@ public class UnifiedStompController {
      */
     @MessageMapping("/room/{roomType}/leave")
     public void leaveRoom(@DestinationVariable String roomType,
-                         @Valid @Payload UnifiedMessageRequest request) {
+                         @Valid @Payload UnifiedMessageRequest request, HttpSession session) {
         try {
             unifiedStompService.leaveRoom(roomType, request);
         } catch (Exception e) {

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -41,6 +41,9 @@ aichat.message-order.turn-start=${AICHAT_MESSAGE_ORDER_TURN_START:0}
 aichat.message-order.turn-end=${AICHAT_MESSAGE_ORDER_TURN_END:9999}
 aichat.message-order.error=${AICHAT_MESSAGE_ORDER_ERROR:9998}
 
+# Session timeout (30분 = 1800초)
+server.servlet.session.timeout=${SERVER_SERVLET_SESSION_TIMEOUT:30m}
+
 # Chat Module Settings
 chat.room.default-max-capacity=${CHAT_ROOM_DEFAULT_MAX_CAPACITY:3}
 


### PR DESCRIPTION
# 요약
WebSocket 연결 끊김 관련 설정 확인 및 수정

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성 
#122 

close #122

# Pull Request 체크리스트

## TODO

- [ ] 최종 결과물을 확인했는가?
- [ ] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 세션 타임아웃 설정을 추가했습니다. 기본값은 30분이며 환경 변수로 조정할 수 있습니다.

- Refactor
  - 채팅, AI 게임, 매칭, 룸 STOMP/WebSocket 엔드포인트에서 세션 처리를 강화해 메시지 전송, 방 참가/이탈, 턴 진행 등의 상호작용 시 세션 연속성과 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->