### PR TITLE
[Chore] Redis Pub/Sub -> Kafka + 테스트 커버리지 측정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.0'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'org.com'
@@ -76,6 +77,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // Spring Boot WebSocket + STOMP
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
@@ -115,6 +119,9 @@ dependencies {
     testImplementation 'org.testcontainers:mongodb'
     testImplementation 'org.testcontainers:postgresql'
 
+    // Kafka Test
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
     // 컴파일 이슈로 인한 주석 처리
 //    testImplementation 'org.testcontainers:redis'
 //    testImplementation 'org.mockito:mockito-inline'
@@ -123,4 +130,41 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
     systemProperty "spring.profiles.active", "test"
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = true
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/config/**',
+                '**/exception/**',
+                '**/dto/**',
+                '**/entity/**',
+                '**/*Application.class'
+            ])
+        }))
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.70
+            }
+        }
+    }
 }

--- a/src/main/java/org/com/dungeontalk/domain/chat/config/ChatAsyncConfig.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/config/ChatAsyncConfig.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * Chat 도메인 전용 비동기 처리 설정
  * - 일반 채팅 메시지 처리용 스레드 풀
  * - Redis Pub/Sub 비동기 처리용 스레드 풀
+ * - Kafka 메시지 발행 비동기 처리용 스레드 풀
  * - Event Listener 비동기 처리용 스레드 풀
  */
 @Slf4j
@@ -70,6 +71,34 @@ public class ChatAsyncConfig {
 
         executor.initialize();
         log.info("chatRedisExecutor 초기화 완료: core={}, max={}, queue={}",
+            executor.getCorePoolSize(), executor.getMaxPoolSize(), executor.getQueueCapacity());
+
+        return executor;
+    }
+
+    /**
+     * Kafka 메시지 발행용 스레드 풀
+     * - Kafka 메시지 발행 비동기 처리
+     * - Kafka 작업 부하를 메인 스레드에서 분리
+     */
+    @Bean(name = "chatKafkaExecutor")
+    public Executor chatKafkaExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(15);
+        executor.setQueueCapacity(100);
+        executor.setKeepAliveSeconds(60);
+        executor.setThreadNamePrefix("Chat-Kafka-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+
+        executor.setRejectedExecutionHandler((runnable, threadPoolExecutor) -> {
+            log.warn("채팅 Kafka 실행자 큐가 가득 찼습니다. 호출 스레드에서 작업을 실행합니다.");
+            runnable.run();
+        });
+
+        executor.initialize();
+        log.info("chatKafkaExecutor 초기화 완료: core={}, max={}, queue={}",
             executor.getCorePoolSize(), executor.getMaxPoolSize(), executor.getQueueCapacity());
 
         return executor;

--- a/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/dto/ChatMessageDto.java
@@ -3,8 +3,10 @@ package org.com.dungeontalk.domain.chat.dto;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.com.dungeontalk.domain.chat.common.MessageType;
 import org.com.dungeontalk.domain.chat.entity.ChatMessage;
@@ -12,6 +14,8 @@ import org.com.dungeontalk.domain.chat.entity.ChatMessage;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageDto {
 
     private String messageId;

--- a/src/main/java/org/com/dungeontalk/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/com/dungeontalk/domain/chat/service/ChatMessageService.java
@@ -18,7 +18,7 @@ import org.com.dungeontalk.domain.member.entity.Member;
 import org.com.dungeontalk.domain.member.repository.MemberRepository;
 import org.com.dungeontalk.global.exception.ErrorCode;
 import org.com.dungeontalk.global.exception.customException.ChatException;
-import org.com.dungeontalk.global.redis.RedisPublisher;
+import org.com.dungeontalk.global.kafka.KafkaPublisher;
 import org.com.dungeontalk.global.util.UuidV7Creator;
 import org.com.dungeontalk.global.filter.ProfanityFilterService;
 import org.com.dungeontalk.global.filter.config.ProfanityFilterProperties;
@@ -34,7 +34,7 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
-    private final RedisPublisher redisPublisher;
+    private final KafkaPublisher kafkaPublisher;
     private final ObjectMapper objectMapper;
     private final ProfanityFilterService profanityFilterService;
     private final ProfanityFilterProperties profanityFilterProperties;
@@ -67,7 +67,7 @@ public class ChatMessageService {
 
         // TALK일 때만 브로드캐스트 (비동기 처리)
         if (chatMessageDto != null) {
-            redisPublisher.publishAsync(dto.getRoomId(), objectMapper.writeValueAsString(chatMessageDto));
+            kafkaPublisher.publishChatAsync(dto.getRoomId(), chatMessageDto);
         }
 
         return chatMessageDto;    // chatMessageDto null이면 컨트롤러는 아무 것도 브로드캐스트하지 않음
@@ -224,8 +224,8 @@ public class ChatMessageService {
                     .createdAt(warningMessage.getCreatedAt())
                     .build();
 
-            // Redis를 통해 브로드캐스트 (비동기 처리)
-            redisPublisher.publishAsync(roomId, objectMapper.writeValueAsString(warningChatDto));
+            // Kafka를 통해 브로드캐스트 (비동기 처리)
+            kafkaPublisher.publishChatAsync(roomId, warningChatDto);
             
         } catch (Exception e) {
             log.error("플레이어 채팅 욕설 경고 메시지 전송 실패: roomId={}, userId={}", roomId, userId, e);

--- a/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
+++ b/src/main/java/org/com/dungeontalk/global/config/SecurityConfig.java
@@ -38,19 +38,22 @@ public class SecurityConfig {
             "/v1/auth/refresh",
             "/v1/auth/server-login",
             "/v1/auth/server-logout",
-            
+
             // 테스트 및 개발용
             "/v1/valkey/session/keys",
             "/v1/valkey/session/all",
             "/v1/valkey/session/test/save",
-            
+
             // 게임 데이터 조회 (읽기 전용)
             "/v1/stat/**",
             "/v1/characters/**",  // v1은 공개, v2는 인증 필요
             "/v1/match/queue-stats",
             "/v1/aichat/rooms/available",
             "/v1/worlds",
-            
+
+            // 채팅 (부하테스트용 - 개발 환경에서만 사용)
+            "/v1/chat/**",                              // 모든 채팅 API 허용
+
             // 초기화 및 WebSocket
             "/init/**",
             "/ws-chat/**"

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -42,6 +42,11 @@ logging.level.org.com.dungeontalk.domain.aichat.service.AiGameMessageService=INF
 logging.level.org.com.dungeontalk.domain.chat.service.ChatMessageService=INFO
 logging.level.root=INFO
 
+# Kafka log level
+logging.level.org.com.dungeontalk.global.kafka=DEBUG
+logging.level.org.springframework.kafka=INFO
+logging.level.org.apache.kafka=WARN
+
 # AI Service Configuration
 ai.service.url=http://localhost:8001
 ai.service.timeout=60000
@@ -80,3 +85,25 @@ profanity-filter.ignore-spaces=true
 profanity-filter.filter-ai-chat=true
 profanity-filter.filter-player-chat=true
 profanity-filter.filter-admin-messages=false
+
+# ======================= Kafka =======================
+
+# Kafka
+spring.kafka.bootstrap-servers=localhost:9092
+
+# Producer
+spring.kafka.producer.acks=1
+spring.kafka.producer.retries=1
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
+# Consumer
+spring.kafka.consumer.group-id=dungeontalk-chat-consumer
+spring.kafka.consumer.auto-offset-reset=latest
+spring.kafka.consumer.enable-auto-commit=true
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=org.com.dungeontalk.*
+
+# Topic
+kafka.topics.chat.regular=dungeontalk.chat.regular

--- a/src/test/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequestTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/dto/request/AiServiceRequestTest.java
@@ -1,101 +1,101 @@
-//package org.com.dungeontalk.domain.aichat.dto.request;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//import java.util.List;
-//
-//class AiServiceRequestTest {
-//
-//    private final ObjectMapper objectMapper = new ObjectMapper();
-//
-//    @Test
-//    @DisplayName("Builder로 객체 생성 테스트")
-//    void builderCreatesObject() {
-//        // given
-//        String gameId = "test-game-123";
-//        String aiGameRoomId = "test-room-456";
-//        String currentUser = "user-789";
-//        String currentMessage = "안녕하세요!";
-//        int turnNumber = 5;
-//
-//        // when
-//        AiServiceRequest result = AiServiceRequest.builder()
-//                .gameId(gameId)
-//                .aiGameRoomId(aiGameRoomId)
-//                .currentUser(currentUser)
-//                .currentMessage(currentMessage)
-//                .turnNumber(turnNumber)
-//                .build();
-//
-//        // then
-//        assertThat(result).isNotNull();
-//        assertThat(result.getGameId()).isEqualTo(gameId);
-//        assertThat(result.getAiGameRoomId()).isEqualTo(aiGameRoomId);
-//        assertThat(result.getCurrentUser()).isEqualTo(currentUser);
-//        assertThat(result.getCurrentMessage()).isEqualTo(currentMessage);
-//        assertThat(result.getTurnNumber()).isEqualTo(turnNumber);
-//    }
-//
-//    //실행되면 파이썬에서도 실행 가능함 왜 이 dto를 실행하느냐 하면  파이썬에서는 카멜 케이스가 아니라 스네이크로 받는데 dto 단에서 오류가
-//    // 발생할수도 있어서 현재 이렇게 했습니다.
-//    @Test
-//    @DisplayName("Java 객체를 JSON으로 변환 (@JsonProperty 매핑 확인)")
-//    void serializeToJson() throws Exception {
-//        // given
-//        AiServiceRequest request = AiServiceRequest.builder()
-//                .gameId("game-123")
-//                .aiGameRoomId("room-456")
-//                .currentUser("user-789")
-//                .currentMessage("테스트 메시지")
-//                .turnNumber(3)
-//                .contextMessages(List.of())
-//                .build();
-//
-//        // when
-//        String json = objectMapper.writeValueAsString(request);
-//
-//        // then - @JsonProperty로 설정한 snake_case 키들이 있는지 확인
-//        assertThat(json).contains("\"game_id\":\"game-123\"");
-//        assertThat(json).contains("\"ai_game_room_id\":\"room-456\"");
-//        assertThat(json).contains("\"current_user\":\"user-789\"");
-//        assertThat(json).contains("\"current_message\":\"테스트 메시지\"");
-//        assertThat(json).contains("\"turn_number\":3");
-//        assertThat(json).contains("\"context_messages\":[]");
-//
-//        // camelCase가 아닌지도 확인 (혹시 @JsonProperty가 안 되었을 경우)
-//        assertThat(json).doesNotContain("gameId");
-//        assertThat(json).doesNotContain("aiGameRoomId");
-//    }
-//
-//    @Test
-//    @DisplayName("JSON을 Java 객체로 변환 (snake_case → camelCase)")
-//    void deserializeFromJson() throws Exception {
-//        // given - Python AI 서비스에서 보낼 수 있는 JSON 형태
-//        String json = """
-//            {
-//                "game_id": "test-game",
-//                "ai_game_room_id": "test-room",
-//                "current_user": "test-user",
-//                "current_message": "안녕하세요",
-//                "turn_number": 7,
-//                "context_messages": []
-//            }
-//            """;
-//
-//        // when
-//        AiServiceRequest result = objectMapper.readValue(json, AiServiceRequest.class);
-//
-//        // then - @JsonProperty 매핑으로 올바르게 변환되었는지 확인
-//        assertThat(result).isNotNull();
-//        assertThat(result.getGameId()).isEqualTo("test-game");
-//        assertThat(result.getAiGameRoomId()).isEqualTo("test-room");
-//        assertThat(result.getCurrentUser()).isEqualTo("test-user");
-//        assertThat(result.getCurrentMessage()).isEqualTo("안녕하세요");
-//        assertThat(result.getTurnNumber()).isEqualTo(7);
-//        assertThat(result.getContextMessages()).isNotNull().isEmpty();
-//    }
-//}
+package org.com.dungeontalk.domain.aichat.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class AiServiceRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Builder로 객체 생성 테스트")
+    void builderCreatesObject() {
+        // given
+        String gameId = "test-game-123";
+        String aiGameRoomId = "test-room-456";
+        String currentUser = "user-789";
+        String currentMessage = "안녕하세요!";
+        int turnNumber = 5;
+
+        // when
+        AiServiceRequest result = AiServiceRequest.builder()
+                .gameId(gameId)
+                .aiGameRoomId(aiGameRoomId)
+                .currentUser(currentUser)
+                .currentMessage(currentMessage)
+                .turnNumber(turnNumber)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getGameId()).isEqualTo(gameId);
+        assertThat(result.getAiGameRoomId()).isEqualTo(aiGameRoomId);
+        assertThat(result.getCurrentUser()).isEqualTo(currentUser);
+        assertThat(result.getCurrentMessage()).isEqualTo(currentMessage);
+        assertThat(result.getTurnNumber()).isEqualTo(turnNumber);
+    }
+
+    //실행되면 파이썬에서도 실행 가능함 왜 이 dto를 실행하느냐 하면  파이썬에서는 카멜 케이스가 아니라 스네이크로 받는데 dto 단에서 오류가
+    // 발생할수도 있어서 현재 이렇게 했습니다.
+    @Test
+    @DisplayName("Java 객체를 JSON으로 변환 (@JsonProperty 매핑 확인)")
+    void serializeToJson() throws Exception {
+        // given
+        AiServiceRequest request = AiServiceRequest.builder()
+                .gameId("game-123")
+                .aiGameRoomId("room-456")
+                .currentUser("user-789")
+                .currentMessage("테스트 메시지")
+                .turnNumber(3)
+                .contextMessages(List.of())
+                .build();
+
+        // when
+        String json = objectMapper.writeValueAsString(request);
+
+        // then - @JsonProperty로 설정한 snake_case 키들이 있는지 확인
+        assertThat(json).contains("\"game_id\":\"game-123\"");
+        assertThat(json).contains("\"ai_game_room_id\":\"room-456\"");
+        assertThat(json).contains("\"current_user\":\"user-789\"");
+        assertThat(json).contains("\"current_message\":\"테스트 메시지\"");
+        assertThat(json).contains("\"turn_number\":3");
+        assertThat(json).contains("\"context_messages\":[]");
+
+        // camelCase가 아닌지도 확인 (혹시 @JsonProperty가 안 되었을 경우)
+        assertThat(json).doesNotContain("gameId");
+        assertThat(json).doesNotContain("aiGameRoomId");
+    }
+
+    @Test
+    @DisplayName("JSON을 Java 객체로 변환 (snake_case → camelCase)")
+    void deserializeFromJson() throws Exception {
+        // given - Python AI 서비스에서 보낼 수 있는 JSON 형태
+        String json = """
+            {
+                "game_id": "test-game",
+                "ai_game_room_id": "test-room",
+                "current_user": "test-user",
+                "current_message": "안녕하세요",
+                "turn_number": 7,
+                "context_messages": []
+            }
+            """;
+
+        // when
+        AiServiceRequest result = objectMapper.readValue(json, AiServiceRequest.class);
+
+        // then - @JsonProperty 매핑으로 올바르게 변환되었는지 확인
+        assertThat(result).isNotNull();
+        assertThat(result.getGameId()).isEqualTo("test-game");
+        assertThat(result.getAiGameRoomId()).isEqualTo("test-room");
+        assertThat(result.getCurrentUser()).isEqualTo("test-user");
+        assertThat(result.getCurrentMessage()).isEqualTo("안녕하세요");
+        assertThat(result.getTurnNumber()).isEqualTo(7);
+        assertThat(result.getContextMessages()).isNotNull().isEmpty();
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/entity/AiGameRoomTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/entity/AiGameRoomTest.java
@@ -1,72 +1,72 @@
-//package org.com.dungeontalk.domain.aichat.entity;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//
-//import java.util.Arrays;
-//import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//
-//class AiGameRoomTest {
-//
-//    @Test
-//    @DisplayName("게임방이 ACTIVE 상태일 때 isActive()는 true를 반환한다.")
-//    void isActive_true_whenStatusActive() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .status(AiGameStatus.ACTIVE)
-//            .maxParticipants(3)
-//            .build();
-//
-//        assertThat(room.isActive()).isTrue();
-//    }
-//
-//    @Test
-//    @DisplayName("게임방이 CREATED 상태이고 정원이 안 찼으면 canJoin()은 true를 반환한다.")
-//    void canJoin_true_whenCreatedAndNotFull() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(3)
-//            .participants(Arrays.asList("m1", "m2"))
-//            .build();
-//
-//        assertThat(room.canJoin()).isTrue();
-//    }
-//
-//    @Test
-//    @DisplayName("게임방이 CREATED 상태지만 정원이 가득 차면 canJoin()은 false")
-//    void canJoin_false_whenFull() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(2)
-//            .participants(Arrays.asList("m1", "m2"))
-//            .build();
-//
-//        assertThat(room.canJoin()).isFalse();
-//    }
-//
-//    @Test
-//    @DisplayName("게임방 참여자 리스트가 null인 경우 getCurrentParticipantCount()는 0")
-//    void getCurrentParticipantCount_returnsZeroIfNull() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(5)
-//            .participants(null)
-//            .build();
-//
-//        assertThat(room.getCurrentParticipantCount()).isZero();
-//    }
-//
-//    @Test
-//    @DisplayName("게임방 참여자 수를 정확하게 반환한다.")
-//    void getCurrentParticipantCount_returnsSize() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(5)
-//            .participants(Arrays.asList("m1", "m2", "m3"))
-//            .build();
-//
-//        assertThat(room.getCurrentParticipantCount()).isEqualTo(3);
-//    }
-//
-//}
+package org.com.dungeontalk.domain.aichat.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AiGameRoomTest {
+
+    @Test
+    @DisplayName("게임방이 ACTIVE 상태일 때 isActive()는 true를 반환한다.")
+    void isActive_true_whenStatusActive() {
+        AiGameRoom room = AiGameRoom.builder()
+            .status(AiGameStatus.ACTIVE)
+            .maxParticipants(3)
+            .build();
+
+        assertThat(room.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("게임방이 CREATED 상태이고 정원이 안 찼으면 canJoin()은 true를 반환한다.")
+    void canJoin_true_whenCreatedAndNotFull() {
+        AiGameRoom room = AiGameRoom.builder()
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(3)
+            .participants(Arrays.asList("m1", "m2"))
+            .build();
+
+        assertThat(room.canJoin()).isTrue();
+    }
+
+    @Test
+    @DisplayName("게임방이 CREATED 상태지만 정원이 가득 차면 canJoin()은 false")
+    void canJoin_false_whenFull() {
+        AiGameRoom room = AiGameRoom.builder()
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(2)
+            .participants(Arrays.asList("m1", "m2"))
+            .build();
+
+        assertThat(room.canJoin()).isFalse();
+    }
+
+    @Test
+    @DisplayName("게임방 참여자 리스트가 null인 경우 getCurrentParticipantCount()는 0")
+    void getCurrentParticipantCount_returnsZeroIfNull() {
+        AiGameRoom room = AiGameRoom.builder()
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(5)
+            .participants(null)
+            .build();
+
+        assertThat(room.getCurrentParticipantCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("게임방 참여자 수를 정확하게 반환한다.")
+    void getCurrentParticipantCount_returnsSize() {
+        AiGameRoom room = AiGameRoom.builder()
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(5)
+            .participants(Arrays.asList("m1", "m2", "m3"))
+            .build();
+
+        assertThat(room.getCurrentParticipantCount()).isEqualTo(3);
+    }
+
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameMessageRepositoryTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameMessageRepositoryTest.java
@@ -1,95 +1,95 @@
-//package org.com.dungeontalk.domain.aichat.repository;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//import java.time.Instant;
-//import java.util.List;
-//import java.util.UUID;
-//
-//import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
-//import org.com.dungeontalk.domain.aichat.common.AiMessageType;
-//import org.junit.jupiter.api.AfterEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-//import org.springframework.data.domain.PageRequest;
-//import org.springframework.test.context.ActiveProfiles;
-//import org.springframework.test.context.DynamicPropertyRegistry;
-//import org.springframework.test.context.DynamicPropertySource;
-//import org.testcontainers.containers.MongoDBContainer;
-//import org.testcontainers.junit.jupiter.Container;
-//import org.testcontainers.junit.jupiter.Testcontainers;
-//
-//@Testcontainers        // Docker 컨테이너 자동 관리
-//@DataMongoTest         // MongoDB Repository 테스트 전용
-//@ActiveProfiles("test") // 테스트 설정 사용
-//class AiGameMessageRepositoryTest {
-//
-//    // MongoDB 컨테이너 설정 (Chat과 동일)
-//    @Container
-//    static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0");
-//
-//    // 컨테이너 URI를 Spring에 주입
-//    @DynamicPropertySource
-//    static void mongoProps(DynamicPropertyRegistry registry) {
-//        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
-//    }
-//
-//    @Autowired
-//    private AiGameMessageRepository repository;
-//
-//    // 테스트 후 데이터 정리 (다른 테스트에 영향 안 주려고)
-//    @AfterEach
-//    void cleanup() {
-//        repository.deleteAll();
-//    }
-//
-//    // 테스트용 메시지 생성 헬퍼 메서드
-//    private AiGameMessage createTestMessage(String roomId, String content, int turnNumber, Instant when) {
-//        return AiGameMessage.builder()
-//                .id(UUID.randomUUID().toString())
-//                .aiGameRoomId(roomId)
-//                .content(content)
-//                .messageType(AiMessageType.USER)
-//                .senderNickname("테스터")
-//                .turnNumber(turnNumber)
-//                .messageOrder(1)
-//                .createdAt(when)
-//                .build();
-//    }
-//
-//    @Test
-//    @DisplayName("메시지 저장 및 조회 기본 테스트")
-//    void saveAndFind() {
-//        // given
-//        AiGameMessage message = createTestMessage("room-1", "안녕하세요", 1, Instant.now());
-//
-//        // when
-//        AiGameMessage saved = repository.save(message);
-//
-//        // then
-//        assertThat(saved.getId()).isNotNull();
-//        assertThat(repository.findById(saved.getId())).isPresent();
-//    }
-//
-//    @Test
-//    @DisplayName("같은 방의 메시지들만 조회되는지 확인")
-//    void findMessagesByRoom() {
-//        // given - 두 개의 다른 방에 메시지 저장
-//        AiGameMessage room1Message = createTestMessage("room-1", "첫 번째 방 메시지", 1, Instant.now());
-//        AiGameMessage room2Message = createTestMessage("room-2", "두 번째 방 메시지", 1, Instant.now());
-//
-//        repository.save(room1Message);
-//        repository.save(room2Message);
-//
-//        // when - room-1의 메시지만 조회
-//        PageRequest pageRequest = PageRequest.of(0, 10); // 최대 10개까지
-//        List<AiGameMessage> result = repository.findByAiGameRoomIdOrderByCreatedAtDesc("room-1", pageRequest);
-//
-//        // then - room-1 메시지만 나와야 함
-//        assertThat(result).hasSize(1);
-//        assertThat(result.get(0).getContent()).isEqualTo("첫 번째 방 메시지");
-//        assertThat(result.get(0).getAiGameRoomId()).isEqualTo("room-1");
-//    }
-//}
+package org.com.dungeontalk.domain.aichat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
+import org.com.dungeontalk.domain.aichat.common.AiMessageType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers        // Docker 컨테이너 자동 관리
+@DataMongoTest         // MongoDB Repository 테스트 전용
+@ActiveProfiles("test") // 테스트 설정 사용
+class AiGameMessageRepositoryTest {
+
+    // MongoDB 컨테이너 설정 (Chat과 동일)
+    @Container
+    static MongoDBContainer mongo = new MongoDBContainer("mongo:7.0");
+
+    // 컨테이너 URI를 Spring에 주입
+    @DynamicPropertySource
+    static void mongoProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongo::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private AiGameMessageRepository repository;
+
+    // 테스트 후 데이터 정리 (다른 테스트에 영향 안 주려고)
+    @AfterEach
+    void cleanup() {
+        repository.deleteAll();
+    }
+
+    // 테스트용 메시지 생성 헬퍼 메서드
+    private AiGameMessage createTestMessage(String roomId, String content, int turnNumber, Instant when) {
+        return AiGameMessage.builder()
+                .id(UUID.randomUUID().toString())
+                .aiGameRoomId(roomId)
+                .content(content)
+                .messageType(AiMessageType.USER)
+                .senderNickname("테스터")
+                .turnNumber(turnNumber)
+                .messageOrder(1)
+                .createdAt(when)
+                .build();
+    }
+
+    @Test
+    @DisplayName("메시지 저장 및 조회 기본 테스트")
+    void saveAndFind() {
+        // given
+        AiGameMessage message = createTestMessage("room-1", "안녕하세요", 1, Instant.now());
+
+        // when
+        AiGameMessage saved = repository.save(message);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(repository.findById(saved.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("같은 방의 메시지들만 조회되는지 확인")
+    void findMessagesByRoom() {
+        // given - 두 개의 다른 방에 메시지 저장
+        AiGameMessage room1Message = createTestMessage("room-1", "첫 번째 방 메시지", 1, Instant.now());
+        AiGameMessage room2Message = createTestMessage("room-2", "두 번째 방 메시지", 1, Instant.now());
+
+        repository.save(room1Message);
+        repository.save(room2Message);
+
+        // when - room-1의 메시지만 조회
+        PageRequest pageRequest = PageRequest.of(0, 10); // 최대 10개까지
+        List<AiGameMessage> result = repository.findByAiGameRoomIdOrderByCreatedAtDesc("room-1", pageRequest);
+
+        // then - room-1 메시지만 나와야 함
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getContent()).isEqualTo("첫 번째 방 메시지");
+        assertThat(result.get(0).getAiGameRoomId()).isEqualTo("room-1");
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameRoomRepositoryTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/repository/AiGameRoomRepositoryTest.java
@@ -1,61 +1,61 @@
-//package org.com.dungeontalk.domain.aichat.repository;
-//
-//import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.Mockito.when;
-//
-//import java.util.List;
-//import java.util.Optional;
-//import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
-//import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//@ExtendWith(MockitoExtension.class)
-//class AiGameRoomRepositoryTest {
-//
-//    @Mock
-//    private AiGameRoomRepository aiGameRoomRepository;
-//
-//    @Test
-//    @DisplayName("findByGameId()로 방을 찾으면 Optional 값이 반환된다")
-//    void findByGameId_returnsOptional() {
-//        AiGameRoom dummy = AiGameRoom.builder()
-//            .id("id-1")
-//            .gameId("game-123")
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(4)
-//            .build();
-//
-//        when(aiGameRoomRepository.findByGameId("game-123")).thenReturn(Optional.of(dummy));
-//
-//        Optional<AiGameRoom> result = aiGameRoomRepository.findByGameId("game-123");
-//
-//        assertThat(result).isPresent();
-//        assertThat(result.get().getGameId()).isEqualTo("game-123");
-//    }
-//
-//    @Test
-//    @DisplayName("findByParticipantsContaining()으로 특정 멤버가 참여한 방 목록 조회")
-//    void findByParticipantsContaining_returnsList() {
-//        AiGameRoom room = AiGameRoom.builder()
-//            .id("room-1")
-//            .gameId("game-xyz")
-//            .participants(List.of("member-1", "member-2"))
-//            .status(AiGameStatus.CREATED)
-//            .maxParticipants(3)
-//            .build();
-//
-//        when(aiGameRoomRepository.findByParticipantsContaining("member-1"))
-//            .thenReturn(List.of(room));
-//
-//        List<AiGameRoom> result = aiGameRoomRepository.findByParticipantsContaining("member-1");
-//
-//        assertThat(result).hasSize(1);
-//        assertThat(result.get(0).getParticipants()).contains("member-1");
-//    }
-//
-//}
+package org.com.dungeontalk.domain.aichat.repository;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
+import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiGameRoomRepositoryTest {
+
+    @Mock
+    private AiGameRoomRepository aiGameRoomRepository;
+
+    @Test
+    @DisplayName("findByGameId()로 방을 찾으면 Optional 값이 반환된다")
+    void findByGameId_returnsOptional() {
+        AiGameRoom dummy = AiGameRoom.builder()
+            .id("id-1")
+            .gameId("game-123")
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(4)
+            .build();
+
+        when(aiGameRoomRepository.findByGameId("game-123")).thenReturn(Optional.of(dummy));
+
+        Optional<AiGameRoom> result = aiGameRoomRepository.findByGameId("game-123");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getGameId()).isEqualTo("game-123");
+    }
+
+    @Test
+    @DisplayName("findByParticipantsContaining()으로 특정 멤버가 참여한 방 목록 조회")
+    void findByParticipantsContaining_returnsList() {
+        AiGameRoom room = AiGameRoom.builder()
+            .id("room-1")
+            .gameId("game-xyz")
+            .participants(List.of("member-1", "member-2"))
+            .status(AiGameStatus.CREATED)
+            .maxParticipants(3)
+            .build();
+
+        when(aiGameRoomRepository.findByParticipantsContaining("member-1"))
+            .thenReturn(List.of(room));
+
+        List<AiGameRoom> result = aiGameRoomRepository.findByParticipantsContaining("member-1");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getParticipants()).contains("member-1");
+    }
+
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageServiceTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameMessageServiceTest.java
@@ -1,153 +1,153 @@
-//package org.com.dungeontalk.domain.aichat.service;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.BDDMockito.given;
-//import static org.mockito.BDDMockito.then;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.com.dungeontalk.domain.aichat.common.AiMessageType;
-//import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
-//import org.com.dungeontalk.domain.aichat.dto.request.AiMessageSaveRequest;
-//import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
-//import org.com.dungeontalk.domain.aichat.repository.AiGameMessageRepository;
-//import org.com.dungeontalk.domain.aichat.repository.AiGameRoomRepository;
-//import org.com.dungeontalk.domain.aichat.util.AiGameValidator;
-//import org.com.dungeontalk.domain.aichat.service.AiGameRoomService;
-//import org.com.dungeontalk.domain.aichat.service.AiGameStateService;
-//import org.com.dungeontalk.global.filter.ProfanityFilterService;
-//import org.com.dungeontalk.global.filter.config.ProfanityFilterProperties;
-//import org.com.dungeontalk.global.redis.RedisPublisher;
-//import org.springframework.context.ApplicationEventPublisher;
-//import org.springframework.messaging.simp.SimpMessagingTemplate;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//import java.time.Instant;
-//import java.util.Collections;
-//
-//@ExtendWith(MockitoExtension.class)
-//class AiGameMessageServiceTest {
-//
-//    @Mock
-//    SimpMessagingTemplate messagingTemplate;
-//
-//    @Mock
-//    AiGameMessageRepository aiGameMessageRepository;
-//
-//    @Mock
-//    AiGameRoomRepository aiGameRoomRepository;
-//
-//    @Mock
-//    AiGameValidator aiGameValidator;
-//
-//    @Mock
-//    RedisPublisher redisPublisher;
-//
-//    @Mock
-//    ObjectMapper objectMapper;
-//
-//    @Mock
-//    ApplicationEventPublisher eventPublisher;
-//
-//    @Mock
-//    AiGameRoomService aiGameRoomService;
-//
-//    @Mock
-//    AiGameStateService aiGameStateService;
-//
-//    @Mock
-//    ProfanityFilterService profanityFilterService;
-//
-//    @Mock
-//    ProfanityFilterProperties profanityFilterProperties;
-//
-//    @InjectMocks
-//    AiGameMessageService aiGameMessageService;
-//
-//    @Test
-//    @DisplayName("AI 메시지 저장 성공 테스트")
-//    void saveAiMessage_success() {
-//        // given
-//        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
-//                .aiGameRoomId("room-123")
-//                .gameId("game-456")
-//                .content("AI 응답 메시지")
-//                .turnNumber(1)
-//                .build();
-//
-//        // Mock: getNextMessageOrder 결과
-//        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
-//                .willReturn(Collections.emptyList());
-//
-//        // Mock: 저장된 메시지 반환
-//        AiGameMessage savedMessage = AiGameMessage.builder()
-//                .id("saved-id")
-//                .aiGameRoomId("room-123")
-//                .gameId("game-456")
-//                .senderId("AI_GM")
-//                .senderNickname("던전 마스터")
-//                .content("AI 응답 메시지")
-//                .messageType(AiMessageType.AI)
-//                .turnNumber(1)
-//                .messageOrder(1)
-//                .createdAt(Instant.now())
-//                .build();
-//
-//        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
-//                .willReturn(savedMessage);
-//
-//        // when
-//        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
-//
-//        // then
-//        assertThat(result).isNotNull();
-//        assertThat(result.getContent()).isEqualTo("AI 응답 메시지");
-//        assertThat(result.getMessageType()).isEqualTo(AiMessageType.AI);
-//        assertThat(result.getTurnNumber()).isEqualTo(1);
-//
-//        // Mock 호출 검증
-//        then(aiGameValidator).should().validateGameRoom("room-123");
-//        then(aiGameMessageRepository).should().save(any(AiGameMessage.class));
-//    }
-//
-//    @Test
-//    @DisplayName("메시지 순서 계산 테스트")
-//    void messageOrder_test() {
-//        // given - 첫 번째 메시지인 경우
-//        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
-//                .aiGameRoomId("room-123")
-//                .gameId("game-456")
-//                .content("첫 번째 메시지")
-//                .turnNumber(1)
-//                .build();
-//
-//        // Mock: 기존 메시지가 없는 경우
-//        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
-//                .willReturn(Collections.emptyList());
-//
-//        AiGameMessage savedMessage = AiGameMessage.builder()
-//                .id("saved-id")
-//                .aiGameRoomId("room-123")
-//                .messageOrder(1) // 첫 번째 메시지이므로 1
-//                .turnNumber(1)
-//                .content("첫 번째 메시지")
-//                .messageType(AiMessageType.AI)
-//                .createdAt(Instant.now())
-//                .build();
-//
-//        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
-//                .willReturn(savedMessage);
-//
-//        // when
-//        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
-//
-//        // then
-//        assertThat(result.getMessageOrder()).isEqualTo(1);
-//        then(aiGameMessageRepository).should().findMaxMessageOrderByTurn("room-123", 1);
-//    }
-//}
+package org.com.dungeontalk.domain.aichat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.com.dungeontalk.domain.aichat.common.AiMessageType;
+import org.com.dungeontalk.domain.aichat.dto.AiGameMessageDto;
+import org.com.dungeontalk.domain.aichat.dto.request.AiMessageSaveRequest;
+import org.com.dungeontalk.domain.aichat.entity.AiGameMessage;
+import org.com.dungeontalk.domain.aichat.repository.AiGameMessageRepository;
+import org.com.dungeontalk.domain.aichat.repository.AiGameRoomRepository;
+import org.com.dungeontalk.domain.aichat.util.AiGameValidator;
+import org.com.dungeontalk.domain.aichat.service.AiGameRoomService;
+import org.com.dungeontalk.domain.aichat.service.AiGameStateService;
+import org.com.dungeontalk.global.filter.ProfanityFilterService;
+import org.com.dungeontalk.global.filter.config.ProfanityFilterProperties;
+import org.com.dungeontalk.global.redis.RedisPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class AiGameMessageServiceTest {
+
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    AiGameMessageRepository aiGameMessageRepository;
+
+    @Mock
+    AiGameRoomRepository aiGameRoomRepository;
+
+    @Mock
+    AiGameValidator aiGameValidator;
+
+    @Mock
+    RedisPublisher redisPublisher;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    AiGameRoomService aiGameRoomService;
+
+    @Mock
+    AiGameStateService aiGameStateService;
+
+    @Mock
+    ProfanityFilterService profanityFilterService;
+
+    @Mock
+    ProfanityFilterProperties profanityFilterProperties;
+
+    @InjectMocks
+    AiGameMessageService aiGameMessageService;
+
+    @Test
+    @DisplayName("AI 메시지 저장 성공 테스트")
+    void saveAiMessage_success() {
+        // given
+        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .content("AI 응답 메시지")
+                .turnNumber(1)
+                .build();
+
+        // Mock: getNextMessageOrder 결과
+        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
+                .willReturn(Collections.emptyList());
+
+        // Mock: 저장된 메시지 반환
+        AiGameMessage savedMessage = AiGameMessage.builder()
+                .id("saved-id")
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .senderId("AI_GM")
+                .senderNickname("던전 마스터")
+                .content("AI 응답 메시지")
+                .messageType(AiMessageType.AI)
+                .turnNumber(1)
+                .messageOrder(1)
+                .createdAt(Instant.now())
+                .build();
+
+        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
+                .willReturn(savedMessage);
+
+        // when
+        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEqualTo("AI 응답 메시지");
+        assertThat(result.getMessageType()).isEqualTo(AiMessageType.AI);
+        assertThat(result.getTurnNumber()).isEqualTo(1);
+
+        // Mock 호출 검증
+        then(aiGameValidator).should().validateGameRoom("room-123");
+        then(aiGameMessageRepository).should().save(any(AiGameMessage.class));
+    }
+
+    @Test
+    @DisplayName("메시지 순서 계산 테스트")
+    void messageOrder_test() {
+        // given - 첫 번째 메시지인 경우
+        AiMessageSaveRequest request = AiMessageSaveRequest.builder()
+                .aiGameRoomId("room-123")
+                .gameId("game-456")
+                .content("첫 번째 메시지")
+                .turnNumber(1)
+                .build();
+
+        // Mock: 기존 메시지가 없는 경우
+        given(aiGameMessageRepository.findMaxMessageOrderByTurn("room-123", 1))
+                .willReturn(Collections.emptyList());
+
+        AiGameMessage savedMessage = AiGameMessage.builder()
+                .id("saved-id")
+                .aiGameRoomId("room-123")
+                .messageOrder(1) // 첫 번째 메시지이므로 1
+                .turnNumber(1)
+                .content("첫 번째 메시지")
+                .messageType(AiMessageType.AI)
+                .createdAt(Instant.now())
+                .build();
+
+        given(aiGameMessageRepository.save(any(AiGameMessage.class)))
+                .willReturn(savedMessage);
+
+        // when
+        AiGameMessageDto result = aiGameMessageService.saveAiMessage(request);
+
+        // then
+        assertThat(result.getMessageOrder()).isEqualTo(1);
+        then(aiGameMessageRepository).should().findMaxMessageOrderByTurn("room-123", 1);
+    }
+}

--- a/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameStateServiceTest.java
+++ b/src/test/java/org/com/dungeontalk/domain/aichat/service/AiGameStateServiceTest.java
@@ -1,477 +1,477 @@
-//package org.com.dungeontalk.domain.aichat.service;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.catchThrowable;
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.mockito.ArgumentMatchers.*;
-//import static org.mockito.BDDMockito.given;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.verifyNoInteractions;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import java.util.List;
-//import java.util.function.Predicate;
-//import org.com.dungeontalk.domain.aichat.common.AiGamePhase;
-//import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
-//import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
-//import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
-//import org.com.dungeontalk.domain.aichat.repository.AiGameRoomRepository;
-//import org.com.dungeontalk.domain.auth.service.ValkeyService;
-//import org.com.dungeontalk.global.exception.customException.AiChatException;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.ArgumentMatcher;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.Spy;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//
-//@ExtendWith(MockitoExtension.class)
-//class AiGameStateServiceTest {
-//
-//    @Mock
-//    private AiGameRoomRepository aiGameRoomRepository;
-//
-//    @Mock
-//    private ValkeyService valkeyService;
-//
-//    @Mock
-//    private AiGameRoomService aiGameRoomService;
-//
-//    @Spy
-//    private ObjectMapper objectMapper = new ObjectMapper();
-//
-//    @InjectMocks
-//    private AiGameStateService service;
-//
-//    private AiGameRoom room(String id, AiGameStatus status, AiGamePhase phase,
-//        int turn, int max, List<String> participants) {
-//        return AiGameRoom.builder()
-//            .id(id)
-//            .gameId("game-1")
-//            .roomName("room-name")
-//            .status(status)
-//            .currentPhase(phase)
-//            .currentTurn(turn)
-//            .maxParticipants(max)
-//            .participants(participants)
-//            .build();
-//    }
-//
-//    // ---- startGameSession ----
-//    @Test
-//    @DisplayName("startGameSession: 이미 ACTIVE인 경우 저장/Valkey 없이 현재 상태 반환")
-//    void startGameSession_alreadyActive() {
-//        String roomId = "r1";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.TURN_INPUT, 3, 4, List.of("u1"));
-//
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
-//
-//        AiGameRoomResponse res = service.startGameSession(roomId);
-//
-//        assertThat(res.getStatus()).isEqualTo(AiGameStatus.ACTIVE);
-//        verify(aiGameRoomRepository, never()).save(any());
-//        verify(valkeyService, never()).setWithExpiration(anyString(), anyString(), anyInt());
-//    }
-//
-//    @Test
-//    @DisplayName("startGameSession: CREATED -> ACTIVE/TURN_INPUT로 저장 & Valkey 세션 저장")
-//    void startGameSession_fromCreated() {
-//        // given
-//        String roomId = "r2";
-//        AiGameRoom created = room(roomId, AiGameStatus.CREATED, null,
-//            1, 4, List.of("u1","u2"));
-//        AiGameRoom after = created.toBuilder()
-//            .status(AiGameStatus.ACTIVE)
-//            .currentPhase(AiGamePhase.TURN_INPUT)
-//            .build();
-//
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
-//        given(aiGameRoomRepository.save(any(AiGameRoom.class))).willReturn(after);
-//
-//        // 키가 정확히 뭔지 몰라도 roomId로 끝나는지만 확인(대소문자 차이/프리픽스 변경에 둔감)
-//        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(false);
-//
-//        // when
-//        AiGameRoomResponse res = service.startGameSession(roomId);
-//
-//        // then
-//        assertThat(res.getStatus()).isEqualTo(AiGameStatus.ACTIVE);
-//        assertThat(res.getCurrentPhase()).isEqualTo(AiGamePhase.TURN_INPUT);
-//
-//        verify(aiGameRoomRepository).save(argThat(saved ->
-//            saved.getStatus() == AiGameStatus.ACTIVE && saved.getCurrentPhase() == AiGamePhase.TURN_INPUT
-//        ));
-//
-//        // 호출 검증도 동일한 매처로
-//        verify(valkeyService).exists(argThat(k -> k != null && k.endsWith(roomId)));
-//        verify(valkeyService).setWithExpiration(
-//            argThat(k -> k != null && k.endsWith(roomId)),
-//            anyString(),
-//            eq(60 * 60)
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("startGameSession: CREATED 이외의 상태인 경우 예외 처리")
-//    void startGameSession_invalidState() {
-//        String roomId = "r3";
-//        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED, AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
-//
-//        Throwable t = catchThrowable(() -> service.startGameSession(roomId));
-//        assertThat(t).isInstanceOf(AiChatException.class);
-//
-//        verify(aiGameRoomRepository, never()).save(any());
-//        verify(valkeyService, never()).setWithExpiration(anyString(), anyString(), anyInt());
-//    }
-//
-//    // ---- changePhase ----
-//    @Test
-//    @DisplayName("changePhase: ACTIVE일 때 phase 변경 저장 + (세션 있으면) 세션 갱신")
-//    void changePhase_success_withSession() {
-//        String roomId = "r4";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE, AiGamePhase.TURN_INPUT,
-//            2, 4, List.of());
-//        AiGamePhase newPhase = AiGamePhase.AI_RESPONSE;
-//
-//        // 1) changePhase 진입용(현재 상태 조회)
-//        // 2) updateSessionPhase 내부에서 다시 조회(최신 데이터로 세션 JSON 재생성)
-//        given(aiGameRoomService.getGameRoomEntity(roomId))
-//            .willReturn(active, active.toBuilder()
-//                .currentPhase(newPhase).build());
-//        given(valkeyService.exists("AI:SESSION:" + roomId)).willReturn(true);
-//
-//        service.changePhase(roomId, newPhase);
-//
-//        verify(aiGameRoomRepository).save(argThat(saved -> saved.getCurrentPhase() == newPhase));
-//
-//        // 세션 갱신 시 JSON 새로 생성 → setWithExpiration 호출
-//        verify(valkeyService).setWithExpiration(eq("AI:SESSION:" + roomId), anyString(), eq(60 * 60));
-//    }
-//
-//    @Test
-//    @DisplayName("changePhase: ACTIVE가 아니면 AiChatException")
-//    void changePhase_invalidState() {
-//        String roomId = "r5";
-//        AiGameRoom created = room(roomId, AiGameStatus.CREATED,
-//            null, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
-//
-//        Throwable t = catchThrowable(() -> service.changePhase(roomId, AiGamePhase.AI_RESPONSE));
-//        assertThat(t).isInstanceOf(AiChatException.class);
-//
-//        verify(aiGameRoomRepository, never()).save(any());
-//    }
-//
-//    // ---- nextTurn(다음 턴) ----
-//    @Test
-//    @DisplayName("nextTurn: ACTIVE일 때 phase 변경 저장 + 세션이 있으면 갱신")
-//    void nextTurn_success_withSession() {
-//        String roomId = "r4";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.TURN_INPUT, 2, 4, List.of());
-//        AiGamePhase newPhase = AiGamePhase.AI_RESPONSE;
-//
-//        // 1) 현재 상태 조회
-//        // 2) updateSessionPhase 내부에서 다시 조회 (세션 JSON 재생성용)
-//        given(aiGameRoomService.getGameRoomEntity(roomId))
-//            .willReturn(active, active.toBuilder().currentPhase(newPhase).build());
-//
-//        // 키의 prefix가 바뀌더라도 roomId로 끝나는지만 매칭
-//        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(true);
-//
-//        // when
-//        service.changePhase(roomId, newPhase);
-//
-//        // then
-//        verify(aiGameRoomRepository).save(argThat(saved -> saved.getCurrentPhase() == newPhase));
-//
-//        // 검증도 같은 matcher를 사용 (정확한 prefix/대소문자 구분하지 않음)
-//        verify(valkeyService).setWithExpiration(
-//            argThat(k -> k != null && k.endsWith(roomId)),
-//            anyString(),
-//            eq(60 * 60)
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("nextTurn: ACTIVE 아니면 IllegalStateException")
-//    void nextTurn_invalidState() {
-//        String roomId = "r7";
-//        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED,
-//            AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
-//
-//        Throwable t = catchThrowable(() -> service.nextTurn(roomId));
-//        assertThat(t).isInstanceOf(IllegalStateException.class);
-//
-//        verify(aiGameRoomRepository, never()).save(any());
-//    }
-//
-//    // ---- lockForAiResponse / unlockAfterAiResponse ----
-//    @Test
-//    @DisplayName("lockForAiResponse: 락 성공 -> changePhase(AI_RESPONSE) 호출 흐름 파악")
-//    void lockForAiResponse_success() {
-//        String roomId = "r8";
-//
-//        // 키/타임아웃이 달라도 roomId만 맞으면 true 주도록 스텁
-//        given(valkeyService.setIfNotExists(
-//            argThat(k -> k != null && k.toLowerCase().contains("turn_lock")
-//                && k.endsWith(roomId)),       // prefix와 case 조건 무시
-//            eq("AI_PROCESSING"),
-//            anyInt()                          // 30 vs 300 차이 무시
-//        )).willReturn(true);
-//
-//        // changePhase가 호출되려면 ACTIVE 상태여야 함
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
-//
-//        // 세션 존재 여부: 구현은 ai_game_session:* 으로 접근 → roomId만 매칭
-//        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(false);
-//
-//        boolean locked = service.lockForAiResponse(roomId);
-//
-//        assertThat(locked).isTrue();
-//
-//        // phase 저장 시도 확인 (AI_RESPONSE 로 바뀌었는지)
-//        verify(aiGameRoomRepository).save(
-//            argThat(saved -> saved.getCurrentPhase() == AiGamePhase.AI_RESPONSE)
-//        );
-//
-//        // 🔎 필요하면 setIfNotExists의 타임아웃이 합리적 범위였는지까지 확인 가능
-//        verify(valkeyService).setIfNotExists(
-//            argThat(k -> k != null && k.toLowerCase().contains("turn_lock") && k.endsWith(roomId)),
-//            eq("AI_PROCESSING"),
-//            intThat(t -> t == 300 || t == 30) // 둘 중 하나면 OK (원하는 쪽만 남겨도 됨)
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("lockForAiResponse: 락 실패 -> false, changePhase 호출 안 함")
-//    void lockForAiResponse_fail() {
-//        String roomId = "r9";
-//
-//        // 🔧 키 prefix/case/timeout 차이 무시하고 roomId만 맞으면 false 반환
-//        given(valkeyService.setIfNotExists(
-//            argThat(k -> k != null
-//                && k.toLowerCase().contains("turn_lock") // ai_game_turn_lock / AI:TURN_LOCK 모두 허용
-//                && k.endsWith(roomId)),
-//            eq("AI_PROCESSING"),
-//            anyInt()    // 30 vs 300 차이 무시
-//        )).willReturn(false);
-//
-//        boolean locked = service.lockForAiResponse(roomId);
-//
-//        assertThat(locked).isFalse();
-//        verify(aiGameRoomRepository, never()).save(any());
-//    }
-//
-//    @Test
-//    @DisplayName("unlockAfterAiResponse: 락 삭제 후 changePhase(TURN_INPUT)")
-//    void unlockAfterAiResponse() {
-//        String roomId = "r10";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.AI_RESPONSE, 1, 4, List.of());
-//
-//        // 현재 상태 조회 -> ACTIVE/AI_RESPONSE
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
-//
-//        // 세션 존재 여부: 키 접두/케이스 다르면 실패하므로 느슨하게 매칭
-//        given(valkeyService.exists(argThat(k ->
-//            k != null &&
-//                k.toLowerCase().contains("session") &&   // ai_game_session / AI:SESSION 모두 허용
-//                k.endsWith(roomId)
-//        ))).willReturn(false);
-//
-//        // 실행
-//        service.unlockAfterAiResponse(roomId);
-//
-//        // 락 삭제: 실제 서비스는 ai_game_turn_lock:<id> 사용 -> 느슨하게 검증
-//        verify(valkeyService).delete(argThat(k ->
-//            k != null &&
-//                k.toLowerCase().contains("turn_lock") &&    // ai_game_turn_lock / AI:TURN_LOCK 모두 허용
-//                k.endsWith(roomId)
-//        ));
-//
-//        // 페이즈 저장 호출 확인
-//        verify(aiGameRoomRepository).save(argThat(saved ->
-//            saved.getCurrentPhase() == AiGamePhase.TURN_INPUT
-//        ));
-//    }
-//
-//    // ---- endGame / pauseGame / resumeGame ----
-//    @Test
-//    @DisplayName("endGame: COMPLETED/GAME_END 저장 + 세션/락 키 삭제")
-//    void endGame_success() {
-//        String roomId = "r11";
-//        AiGameRoom any = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.TURN_INPUT, 2, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(any);
-//
-//        service.endGame(roomId);
-//
-//        // 상태/페이즈 저장 검증
-//        verify(aiGameRoomRepository).save(argThat(saved ->
-//            saved.getStatus() == AiGameStatus.COMPLETED &&
-//                saved.getCurrentPhase() == AiGamePhase.GAME_END
-//        ));
-//
-//        // 키 삭제 검증: 접두사/대소문자 차이는 허용, roomId 일치만 보면 됨
-//        verify(valkeyService).delete(argThat(k ->
-//            k != null && k.toLowerCase().contains("session") && k.endsWith(roomId)
-//        ));
-//        verify(valkeyService).delete(argThat(k ->
-//            k != null && k.toLowerCase().contains("turn_lock") && k.endsWith(roomId)
-//        ));
-//    }
-//
-//    @Test
-//    @DisplayName("pauseGame: ACTIVE 아니면 IllegalStateException")
-//    void pauseGame_invalidState() {
-//        String roomId = "r12";
-//        AiGameRoom created = room(roomId, AiGameStatus.CREATED, null, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
-//
-//        Throwable t = catchThrowable(() -> service.pauseGame(roomId, "reason"));
-//        assertThat(t).isInstanceOf(IllegalStateException.class);
-//
-//        verify(aiGameRoomRepository, never()).save(any());
-//    }
-//
-//    @Test
-//    @DisplayName("pauseGame: ACTIVE -> PAUSED 저장 + 락 해제")
-//    void pauseGame_success() {
-//        String roomId = "r13";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
-//            AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
-//
-//        service.pauseGame(roomId, "cooldown");
-//
-//        // 상태만 정확히 보면 됨
-//        verify(aiGameRoomRepository).save(argThat(saved ->
-//            saved.getStatus() == AiGameStatus.PAUSED
-//        ));
-//
-//        // 락 키는 구현 키 접두사/대소문자 변화에 자유롭게 검증
-//        verify(valkeyService).delete(argThat(k ->
-//            k != null &&
-//                k.toLowerCase().contains("turn_lock") &&  // 역할
-//                k.endsWith(roomId)                        // 대상
-//        ));
-//    }
-//
-//    @Test
-//    @DisplayName("resumeGame: PAUSED 아니면 AiChatException")
-//    void resumeGame_invalidState() {
-//        String roomId = "r14";
-//        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE, AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
-//
-//        Throwable t = catchThrowable(() -> service.resumeGame(roomId));
-//        assertThat(t).isInstanceOf(AiChatException.class);
-//
-//        verify(aiGameRoomRepository, never()).save(any());
-//    }
-//
-//    @Test
-//    @DisplayName("resumeGame: PAUSED → ACTIVE/TURN_INPUT 저장")
-//    void resumeGame_success() {
-//        String roomId = "r15";
-//        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED, AiGamePhase.TURN_INPUT, 1, 4, List.of());
-//        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
-//
-//        service.resumeGame(roomId);
-//
-//        verify(aiGameRoomRepository).save(argThat(saved ->
-//            saved.getStatus() == AiGameStatus.ACTIVE && saved.getCurrentPhase() == AiGamePhase.TURN_INPUT));
-//    }
-//
-//    // ---- session helpers ----
-//    @Test
-//    @DisplayName("isSessionValid: 세션 쪽 키 존재 여부 반환")
-//    void isSessionValid() {
-//        String roomId = "r16";
-//
-//        // 세션 키 형태와 roomId만 맞으면 OK
-//        ArgumentMatcher<String> sessionKeyOfRoom = k ->
-//            k != null &&
-//                k.toLowerCase().contains("session") &&      // 역할(세션 키)
-//                k.endsWith(roomId);                         // 대상(roomId)
-//
-//        // 한 번은 true, 그 다음은 false 반환
-//        given(valkeyService.exists(argThat(sessionKeyOfRoom)))
-//            .willReturn(true, false);
-//
-//        assertThat(service.isSessionValid(roomId)).isTrue();
-//        assertThat(service.isSessionValid(roomId)).isFalse();
-//
-//        // 정확히 2회 호출되었는지만 확인 (키 문자열은 매처로 검증)
-//        verify(valkeyService, times(2)).exists(argThat(sessionKeyOfRoom));
-//    }
-//
-//    @Test
-//    @DisplayName("isAiProcessing: 락 키 존재 여부 반환")
-//    void isAiProcessing() {
-//        String roomId = "r17";
-//
-//        // "turn lock" 용도이며 대상 roomId를 가리키는 키라면 OK
-//        ArgumentMatcher<String> turnLockKeyOfRoom = k ->
-//            k != null &&
-//                k.toLowerCase().contains("turn") &&     // 턴 락 키
-//                k.toLowerCase().contains("lock") &&     // 락
-//                k.endsWith(roomId);                     // 대상 roomId
-//
-//        // exists 호출 결과 true 반환
-//        given(valkeyService.exists(argThat(turnLockKeyOfRoom))).willReturn(true);
-//
-//        assertThat(service.isAiProcessing(roomId)).isTrue();
-//
-//        // 정확히 해당 형태의 키로 exists가 호출이 되었는지를 검증
-//        verify(valkeyService).exists(argThat(turnLockKeyOfRoom));
-//    }
-//
-//    @Test
-//    @DisplayName("extendSession: 세션이 존재할 때만 expire 호출")
-//    void extendSession() {
-//        String roomId = "r18";
-//
-//        // 세션 키 매처: "session" 용도이며 대상 roomId로 끝나면 OK
-//        var sessionKeyOfRoom = (Predicate<String>) k ->
-//            k != null &&
-//                k.toLowerCase().contains("session") &&
-//                k.endsWith(roomId);
-//
-//        // exists → 첫 호출 true, 두 번째 false
-//        given(valkeyService.exists(argThat(k -> sessionKeyOfRoom.test(k))))
-//            .willReturn(true, false);
-//
-//        // when
-//        service.extendSession(roomId); // true → expire 호출
-//        service.extendSession(roomId); // false → expire 호출 안 함
-//
-//        // then
-//        verify(valkeyService)
-//            .expire(argThat(k -> sessionKeyOfRoom.test(k)), eq(60 * 60));
-//        verify(valkeyService,
-//            times(2)).exists(argThat(k -> sessionKeyOfRoom.test(k)));
-//    }
-//
-//    @Test
-//    @DisplayName("cleanupInactiveGames: 현재는 no-op (호출만 검증)")
-//    void cleanupInactiveGames_noop() {
-//        service.cleanupInactiveGames(6);
-//
-//        // 현재 구현이 no-op 이므로 상호작용이 없어야 정상
-//        verifyNoInteractions(aiGameRoomRepository);
-//    }
-//
-//
-//}
+package org.com.dungeontalk.domain.aichat.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.function.Predicate;
+import org.com.dungeontalk.domain.aichat.common.AiGamePhase;
+import org.com.dungeontalk.domain.aichat.common.AiGameStatus;
+import org.com.dungeontalk.domain.aichat.dto.response.AiGameRoomResponse;
+import org.com.dungeontalk.domain.aichat.entity.AiGameRoom;
+import org.com.dungeontalk.domain.aichat.repository.AiGameRoomRepository;
+import org.com.dungeontalk.domain.auth.service.ValkeyService;
+import org.com.dungeontalk.global.exception.customException.AiChatException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AiGameStateServiceTest {
+
+    @Mock
+    private AiGameRoomRepository aiGameRoomRepository;
+
+    @Mock
+    private ValkeyService valkeyService;
+
+    @Mock
+    private AiGameRoomService aiGameRoomService;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private AiGameStateService service;
+
+    private AiGameRoom room(String id, AiGameStatus status, AiGamePhase phase,
+        int turn, int max, List<String> participants) {
+        return AiGameRoom.builder()
+            .id(id)
+            .gameId("game-1")
+            .roomName("room-name")
+            .status(status)
+            .currentPhase(phase)
+            .currentTurn(turn)
+            .maxParticipants(max)
+            .participants(participants)
+            .build();
+    }
+
+    // ---- startGameSession ----
+    @Test
+    @DisplayName("startGameSession: 이미 ACTIVE인 경우 저장/Valkey 없이 현재 상태 반환")
+    void startGameSession_alreadyActive() {
+        String roomId = "r1";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.TURN_INPUT, 3, 4, List.of("u1"));
+
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
+
+        AiGameRoomResponse res = service.startGameSession(roomId);
+
+        assertThat(res.getStatus()).isEqualTo(AiGameStatus.ACTIVE);
+        verify(aiGameRoomRepository, never()).save(any());
+        verify(valkeyService, never()).setWithExpiration(anyString(), anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("startGameSession: CREATED -> ACTIVE/TURN_INPUT로 저장 & Valkey 세션 저장")
+    void startGameSession_fromCreated() {
+        // given
+        String roomId = "r2";
+        AiGameRoom created = room(roomId, AiGameStatus.CREATED, null,
+            1, 4, List.of("u1","u2"));
+        AiGameRoom after = created.toBuilder()
+            .status(AiGameStatus.ACTIVE)
+            .currentPhase(AiGamePhase.TURN_INPUT)
+            .build();
+
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
+        given(aiGameRoomRepository.save(any(AiGameRoom.class))).willReturn(after);
+
+        // 키가 정확히 뭔지 몰라도 roomId로 끝나는지만 확인(대소문자 차이/프리픽스 변경에 둔감)
+        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(false);
+
+        // when
+        AiGameRoomResponse res = service.startGameSession(roomId);
+
+        // then
+        assertThat(res.getStatus()).isEqualTo(AiGameStatus.ACTIVE);
+        assertThat(res.getCurrentPhase()).isEqualTo(AiGamePhase.TURN_INPUT);
+
+        verify(aiGameRoomRepository).save(argThat(saved ->
+            saved.getStatus() == AiGameStatus.ACTIVE && saved.getCurrentPhase() == AiGamePhase.TURN_INPUT
+        ));
+
+        // 호출 검증도 동일한 매처로
+        verify(valkeyService).exists(argThat(k -> k != null && k.endsWith(roomId)));
+        verify(valkeyService).setWithExpiration(
+            argThat(k -> k != null && k.endsWith(roomId)),
+            anyString(),
+            eq(60 * 60)
+        );
+    }
+
+    @Test
+    @DisplayName("startGameSession: CREATED 이외의 상태인 경우 예외 처리")
+    void startGameSession_invalidState() {
+        String roomId = "r3";
+        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED, AiGamePhase.TURN_INPUT, 1, 4, List.of());
+
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
+
+        Throwable t = catchThrowable(() -> service.startGameSession(roomId));
+        assertThat(t).isInstanceOf(AiChatException.class);
+
+        verify(aiGameRoomRepository, never()).save(any());
+        verify(valkeyService, never()).setWithExpiration(anyString(), anyString(), anyInt());
+    }
+
+    // ---- changePhase ----
+    @Test
+    @DisplayName("changePhase: ACTIVE일 때 phase 변경 저장 + (세션 있으면) 세션 갱신")
+    void changePhase_success_withSession() {
+        String roomId = "r4";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE, AiGamePhase.TURN_INPUT,
+            2, 4, List.of());
+        AiGamePhase newPhase = AiGamePhase.AI_RESPONSE;
+
+        // 1) changePhase 진입용(현재 상태 조회)
+        // 2) updateSessionPhase 내부에서 다시 조회(최신 데이터로 세션 JSON 재생성)
+        given(aiGameRoomService.getGameRoomEntity(roomId))
+            .willReturn(active, active.toBuilder()
+                .currentPhase(newPhase).build());
+        given(valkeyService.exists("AI:SESSION:" + roomId)).willReturn(true);
+
+        service.changePhase(roomId, newPhase);
+
+        verify(aiGameRoomRepository).save(argThat(saved -> saved.getCurrentPhase() == newPhase));
+
+        // 세션 갱신 시 JSON 새로 생성 → setWithExpiration 호출
+        verify(valkeyService).setWithExpiration(eq("AI:SESSION:" + roomId), anyString(), eq(60 * 60));
+    }
+
+    @Test
+    @DisplayName("changePhase: ACTIVE가 아니면 AiChatException")
+    void changePhase_invalidState() {
+        String roomId = "r5";
+        AiGameRoom created = room(roomId, AiGameStatus.CREATED,
+            null, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
+
+        Throwable t = catchThrowable(() -> service.changePhase(roomId, AiGamePhase.AI_RESPONSE));
+        assertThat(t).isInstanceOf(AiChatException.class);
+
+        verify(aiGameRoomRepository, never()).save(any());
+    }
+
+    // ---- nextTurn(다음 턴) ----
+    @Test
+    @DisplayName("nextTurn: ACTIVE일 때 phase 변경 저장 + 세션이 있으면 갱신")
+    void nextTurn_success_withSession() {
+        String roomId = "r4";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.TURN_INPUT, 2, 4, List.of());
+        AiGamePhase newPhase = AiGamePhase.AI_RESPONSE;
+
+        // 1) 현재 상태 조회
+        // 2) updateSessionPhase 내부에서 다시 조회 (세션 JSON 재생성용)
+        given(aiGameRoomService.getGameRoomEntity(roomId))
+            .willReturn(active, active.toBuilder().currentPhase(newPhase).build());
+
+        // 키의 prefix가 바뀌더라도 roomId로 끝나는지만 매칭
+        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(true);
+
+        // when
+        service.changePhase(roomId, newPhase);
+
+        // then
+        verify(aiGameRoomRepository).save(argThat(saved -> saved.getCurrentPhase() == newPhase));
+
+        // 검증도 같은 matcher를 사용 (정확한 prefix/대소문자 구분하지 않음)
+        verify(valkeyService).setWithExpiration(
+            argThat(k -> k != null && k.endsWith(roomId)),
+            anyString(),
+            eq(60 * 60)
+        );
+    }
+
+    @Test
+    @DisplayName("nextTurn: ACTIVE 아니면 IllegalStateException")
+    void nextTurn_invalidState() {
+        String roomId = "r7";
+        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED,
+            AiGamePhase.TURN_INPUT, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
+
+        Throwable t = catchThrowable(() -> service.nextTurn(roomId));
+        assertThat(t).isInstanceOf(IllegalStateException.class);
+
+        verify(aiGameRoomRepository, never()).save(any());
+    }
+
+    // ---- lockForAiResponse / unlockAfterAiResponse ----
+    @Test
+    @DisplayName("lockForAiResponse: 락 성공 -> changePhase(AI_RESPONSE) 호출 흐름 파악")
+    void lockForAiResponse_success() {
+        String roomId = "r8";
+
+        // 키/타임아웃이 달라도 roomId만 맞으면 true 주도록 스텁
+        given(valkeyService.setIfNotExists(
+            argThat(k -> k != null && k.toLowerCase().contains("turn_lock")
+                && k.endsWith(roomId)),       // prefix와 case 조건 무시
+            eq("AI_PROCESSING"),
+            anyInt()                          // 30 vs 300 차이 무시
+        )).willReturn(true);
+
+        // changePhase가 호출되려면 ACTIVE 상태여야 함
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.TURN_INPUT, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
+
+        // 세션 존재 여부: 구현은 ai_game_session:* 으로 접근 → roomId만 매칭
+        given(valkeyService.exists(argThat(k -> k != null && k.endsWith(roomId)))).willReturn(false);
+
+        boolean locked = service.lockForAiResponse(roomId);
+
+        assertThat(locked).isTrue();
+
+        // phase 저장 시도 확인 (AI_RESPONSE 로 바뀌었는지)
+        verify(aiGameRoomRepository).save(
+            argThat(saved -> saved.getCurrentPhase() == AiGamePhase.AI_RESPONSE)
+        );
+
+        // 🔎 필요하면 setIfNotExists의 타임아웃이 합리적 범위였는지까지 확인 가능
+        verify(valkeyService).setIfNotExists(
+            argThat(k -> k != null && k.toLowerCase().contains("turn_lock") && k.endsWith(roomId)),
+            eq("AI_PROCESSING"),
+            intThat(t -> t == 300 || t == 30) // 둘 중 하나면 OK (원하는 쪽만 남겨도 됨)
+        );
+    }
+
+    @Test
+    @DisplayName("lockForAiResponse: 락 실패 -> false, changePhase 호출 안 함")
+    void lockForAiResponse_fail() {
+        String roomId = "r9";
+
+        // 🔧 키 prefix/case/timeout 차이 무시하고 roomId만 맞으면 false 반환
+        given(valkeyService.setIfNotExists(
+            argThat(k -> k != null
+                && k.toLowerCase().contains("turn_lock") // ai_game_turn_lock / AI:TURN_LOCK 모두 허용
+                && k.endsWith(roomId)),
+            eq("AI_PROCESSING"),
+            anyInt()    // 30 vs 300 차이 무시
+        )).willReturn(false);
+
+        boolean locked = service.lockForAiResponse(roomId);
+
+        assertThat(locked).isFalse();
+        verify(aiGameRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("unlockAfterAiResponse: 락 삭제 후 changePhase(TURN_INPUT)")
+    void unlockAfterAiResponse() {
+        String roomId = "r10";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.AI_RESPONSE, 1, 4, List.of());
+
+        // 현재 상태 조회 -> ACTIVE/AI_RESPONSE
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
+
+        // 세션 존재 여부: 키 접두/케이스 다르면 실패하므로 느슨하게 매칭
+        given(valkeyService.exists(argThat(k ->
+            k != null &&
+                k.toLowerCase().contains("session") &&   // ai_game_session / AI:SESSION 모두 허용
+                k.endsWith(roomId)
+        ))).willReturn(false);
+
+        // 실행
+        service.unlockAfterAiResponse(roomId);
+
+        // 락 삭제: 실제 서비스는 ai_game_turn_lock:<id> 사용 -> 느슨하게 검증
+        verify(valkeyService).delete(argThat(k ->
+            k != null &&
+                k.toLowerCase().contains("turn_lock") &&    // ai_game_turn_lock / AI:TURN_LOCK 모두 허용
+                k.endsWith(roomId)
+        ));
+
+        // 페이즈 저장 호출 확인
+        verify(aiGameRoomRepository).save(argThat(saved ->
+            saved.getCurrentPhase() == AiGamePhase.TURN_INPUT
+        ));
+    }
+
+    // ---- endGame / pauseGame / resumeGame ----
+    @Test
+    @DisplayName("endGame: COMPLETED/GAME_END 저장 + 세션/락 키 삭제")
+    void endGame_success() {
+        String roomId = "r11";
+        AiGameRoom any = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.TURN_INPUT, 2, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(any);
+
+        service.endGame(roomId);
+
+        // 상태/페이즈 저장 검증
+        verify(aiGameRoomRepository).save(argThat(saved ->
+            saved.getStatus() == AiGameStatus.COMPLETED &&
+                saved.getCurrentPhase() == AiGamePhase.GAME_END
+        ));
+
+        // 키 삭제 검증: 접두사/대소문자 차이는 허용, roomId 일치만 보면 됨
+        verify(valkeyService).delete(argThat(k ->
+            k != null && k.toLowerCase().contains("session") && k.endsWith(roomId)
+        ));
+        verify(valkeyService).delete(argThat(k ->
+            k != null && k.toLowerCase().contains("turn_lock") && k.endsWith(roomId)
+        ));
+    }
+
+    @Test
+    @DisplayName("pauseGame: ACTIVE 아니면 IllegalStateException")
+    void pauseGame_invalidState() {
+        String roomId = "r12";
+        AiGameRoom created = room(roomId, AiGameStatus.CREATED, null, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(created);
+
+        Throwable t = catchThrowable(() -> service.pauseGame(roomId, "reason"));
+        assertThat(t).isInstanceOf(IllegalStateException.class);
+
+        verify(aiGameRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("pauseGame: ACTIVE -> PAUSED 저장 + 락 해제")
+    void pauseGame_success() {
+        String roomId = "r13";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE,
+            AiGamePhase.TURN_INPUT, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
+
+        service.pauseGame(roomId, "cooldown");
+
+        // 상태만 정확히 보면 됨
+        verify(aiGameRoomRepository).save(argThat(saved ->
+            saved.getStatus() == AiGameStatus.PAUSED
+        ));
+
+        // 락 키는 구현 키 접두사/대소문자 변화에 자유롭게 검증
+        verify(valkeyService).delete(argThat(k ->
+            k != null &&
+                k.toLowerCase().contains("turn_lock") &&  // 역할
+                k.endsWith(roomId)                        // 대상
+        ));
+    }
+
+    @Test
+    @DisplayName("resumeGame: PAUSED 아니면 AiChatException")
+    void resumeGame_invalidState() {
+        String roomId = "r14";
+        AiGameRoom active = room(roomId, AiGameStatus.ACTIVE, AiGamePhase.TURN_INPUT, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(active);
+
+        Throwable t = catchThrowable(() -> service.resumeGame(roomId));
+        assertThat(t).isInstanceOf(AiChatException.class);
+
+        verify(aiGameRoomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("resumeGame: PAUSED → ACTIVE/TURN_INPUT 저장")
+    void resumeGame_success() {
+        String roomId = "r15";
+        AiGameRoom paused = room(roomId, AiGameStatus.PAUSED, AiGamePhase.TURN_INPUT, 1, 4, List.of());
+        given(aiGameRoomService.getGameRoomEntity(roomId)).willReturn(paused);
+
+        service.resumeGame(roomId);
+
+        verify(aiGameRoomRepository).save(argThat(saved ->
+            saved.getStatus() == AiGameStatus.ACTIVE && saved.getCurrentPhase() == AiGamePhase.TURN_INPUT));
+    }
+
+    // ---- session helpers ----
+    @Test
+    @DisplayName("isSessionValid: 세션 쪽 키 존재 여부 반환")
+    void isSessionValid() {
+        String roomId = "r16";
+
+        // 세션 키 형태와 roomId만 맞으면 OK
+        ArgumentMatcher<String> sessionKeyOfRoom = k ->
+            k != null &&
+                k.toLowerCase().contains("session") &&      // 역할(세션 키)
+                k.endsWith(roomId);                         // 대상(roomId)
+
+        // 한 번은 true, 그 다음은 false 반환
+        given(valkeyService.exists(argThat(sessionKeyOfRoom)))
+            .willReturn(true, false);
+
+        assertThat(service.isSessionValid(roomId)).isTrue();
+        assertThat(service.isSessionValid(roomId)).isFalse();
+
+        // 정확히 2회 호출되었는지만 확인 (키 문자열은 매처로 검증)
+        verify(valkeyService, times(2)).exists(argThat(sessionKeyOfRoom));
+    }
+
+    @Test
+    @DisplayName("isAiProcessing: 락 키 존재 여부 반환")
+    void isAiProcessing() {
+        String roomId = "r17";
+
+        // "turn lock" 용도이며 대상 roomId를 가리키는 키라면 OK
+        ArgumentMatcher<String> turnLockKeyOfRoom = k ->
+            k != null &&
+                k.toLowerCase().contains("turn") &&     // 턴 락 키
+                k.toLowerCase().contains("lock") &&     // 락
+                k.endsWith(roomId);                     // 대상 roomId
+
+        // exists 호출 결과 true 반환
+        given(valkeyService.exists(argThat(turnLockKeyOfRoom))).willReturn(true);
+
+        assertThat(service.isAiProcessing(roomId)).isTrue();
+
+        // 정확히 해당 형태의 키로 exists가 호출이 되었는지를 검증
+        verify(valkeyService).exists(argThat(turnLockKeyOfRoom));
+    }
+
+    @Test
+    @DisplayName("extendSession: 세션이 존재할 때만 expire 호출")
+    void extendSession() {
+        String roomId = "r18";
+
+        // 세션 키 매처: "session" 용도이며 대상 roomId로 끝나면 OK
+        var sessionKeyOfRoom = (Predicate<String>) k ->
+            k != null &&
+                k.toLowerCase().contains("session") &&
+                k.endsWith(roomId);
+
+        // exists → 첫 호출 true, 두 번째 false
+        given(valkeyService.exists(argThat(k -> sessionKeyOfRoom.test(k))))
+            .willReturn(true, false);
+
+        // when
+        service.extendSession(roomId); // true → expire 호출
+        service.extendSession(roomId); // false → expire 호출 안 함
+
+        // then
+        verify(valkeyService)
+            .expire(argThat(k -> sessionKeyOfRoom.test(k)), eq(60 * 60));
+        verify(valkeyService,
+            times(2)).exists(argThat(k -> sessionKeyOfRoom.test(k)));
+    }
+
+    @Test
+    @DisplayName("cleanupInactiveGames: 현재는 no-op (호출만 검증)")
+    void cleanupInactiveGames_noop() {
+        service.cleanupInactiveGames(6);
+
+        // 현재 구현이 no-op 이므로 상호작용이 없어야 정상
+        verifyNoInteractions(aiGameRoomRepository);
+    }
+
+
+}


### PR DESCRIPTION
# 요약

1. Redis Pub/Sub -> Kafka 로 전환
2. JaCoCo 활용한 테스트 커버리지 측정

# 연관 이슈 및 Close 할 이슈 작성

-- PR 시 다음과 같이 작성 
#133

close #133

# Pull Request 체크리스트

## TODO
- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
  - 좋은 예시) feat: 깃허브 로그인 버튼 컴포넌트 구현 (#10)
  - 나쁜 예시) feat: 로그인 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 실시간 채팅 전송을 Kafka 기반으로 개선하여 안정성과 확장성 향상
  - 채팅 API 경로(/v1/chat/**)를 인증 없이 접근 가능하도록 공개

- Tests
  - AI 채팅 관련 DTO, 엔티티, 리포지토리, 서비스 테스트 다수 추가/활성화로 커버리지 및 신뢰성 향상

- Chores
  - 코드 커버리지 도구(JaCoCo) 도입 및 빌드 파이프라인 연동
  - 개발 환경에 Kafka 설정 추가(프로듀서/컨슈머, 직렬화/역직렬화, 토픽 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->